### PR TITLE
Fixed name of assertion function.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ class CLITests(TestCase):
     def test_main_should_call_correct_function(self, mock_version):
         result = self.runner.invoke(main, ['version'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once_with()
+        mock_version.assert_called_once_with(noop=False, force_level=None)
 
     @mock.patch('semantic_release.cli.config.getboolean', lambda *x: False)
     @mock.patch('semantic_release.cli.tag_new_version')
@@ -39,21 +39,21 @@ class CLITests(TestCase):
     def test_force_major(self, mock_version):
         result = self.runner.invoke(main, ['version', '--major'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once_with()
+        mock_version.assert_called_once_with(noop=False, force_level='major')
         self.assertEqual(mock_version.call_args_list[0][1]['force_level'], 'major')
 
     @mock.patch('semantic_release.cli.version')
     def test_force_minor(self, mock_version):
         result = self.runner.invoke(main, ['version', '--minor'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once_with()
+        mock_version.assert_called_once_with(noop=False, force_level='minor')
         self.assertEqual(mock_version.call_args_list[0][1]['force_level'], 'minor')
 
     @mock.patch('semantic_release.cli.version')
     def test_force_patch(self, mock_version):
         result = self.runner.invoke(main, ['version', '--patch'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once_with()
+        mock_version.assert_called_once_with(noop=False, force_level='patch')
         self.assertEqual(mock_version.call_args_list[0][1]['force_level'], 'patch')
 
     @mock.patch('semantic_release.cli.tag_new_version')
@@ -131,7 +131,7 @@ class CLITests(TestCase):
     def test_publish_should_do_nothing(self, mock_version, mock_push, mock_upload):
         result = self.runner.invoke(main, ['publish'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once_with()
+        mock_version.assert_called_once_with(noop=False, force_level=None)
         self.assertFalse(mock_push.called)
         self.assertFalse(mock_upload.called)
 
@@ -141,6 +141,6 @@ class CLITests(TestCase):
     def test_publish_should_call_functions(self, mock_version, mock_push, mock_upload):
         result = self.runner.invoke(main, ['publish'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once_with()
+        mock_version.assert_called_once_with(noop=False, force_level=None)
         mock_push.assert_called_once_with()
         mock_upload.assert_called_once_with()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ class CLITests(TestCase):
     def test_main_should_call_correct_function(self, mock_version):
         result = self.runner.invoke(main, ['version'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once()
+        mock_version.assert_called_once_with()
 
     @mock.patch('semantic_release.cli.config.getboolean', lambda *x: False)
     @mock.patch('semantic_release.cli.tag_new_version')
@@ -39,21 +39,21 @@ class CLITests(TestCase):
     def test_force_major(self, mock_version):
         result = self.runner.invoke(main, ['version', '--major'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once()
+        mock_version.assert_called_once_with()
         self.assertEqual(mock_version.call_args_list[0][1]['force_level'], 'major')
 
     @mock.patch('semantic_release.cli.version')
     def test_force_minor(self, mock_version):
         result = self.runner.invoke(main, ['version', '--minor'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once()
+        mock_version.assert_called_once_with()
         self.assertEqual(mock_version.call_args_list[0][1]['force_level'], 'minor')
 
     @mock.patch('semantic_release.cli.version')
     def test_force_patch(self, mock_version):
         result = self.runner.invoke(main, ['version', '--patch'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once()
+        mock_version.assert_called_once_with()
         self.assertEqual(mock_version.call_args_list[0][1]['force_level'], 'patch')
 
     @mock.patch('semantic_release.cli.tag_new_version')
@@ -131,7 +131,7 @@ class CLITests(TestCase):
     def test_publish_should_do_nothing(self, mock_version, mock_push, mock_upload):
         result = self.runner.invoke(main, ['publish'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once()
+        mock_version.assert_called_once_with()
         self.assertFalse(mock_push.called)
         self.assertFalse(mock_upload.called)
 
@@ -141,6 +141,6 @@ class CLITests(TestCase):
     def test_publish_should_call_functions(self, mock_version, mock_push, mock_upload):
         result = self.runner.invoke(main, ['publish'])
         self.assertEqual(result.exit_code, 0)
-        mock_version.assert_called_once()
-        mock_push.assert_called_once()
-        mock_upload.assert_called_once()
+        mock_version.assert_called_once_with()
+        mock_push.assert_called_once_with()
+        mock_upload.assert_called_once_with()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,7 @@ class ConfigTests(TestCase):
     @mock.patch('semantic_release.settings.getcwd', return_value='/tmp/')
     def test_defaults(self, mock_getcwd):
         config = _config()
-        mock_getcwd.assert_called_once()
+        mock_getcwd.assert_called_once_with()
         self.assertEqual(config.get('semantic_release', 'major_tag'), ':boom:')
         self.assertEqual(config.get('semantic_release', 'minor_tag'), ':sparkles:')
         self.assertEqual(config.get('semantic_release', 'patch_tag'), ':bug:')


### PR DESCRIPTION
Seems like this snuck in and tested for the wrong thing. The assertion function
is called assert_called_once_with(), only running assert_called_once() will
call the mock instead.

Refs #10.