### PR TITLE
add option to use tag instead of creating new commit when versioning

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -62,18 +62,13 @@ def version(**kwargs):
         if not check_build_status(owner, name, get_current_head_hash()):
             click.echo(click.style('The build has failed', 'red'))
             return False
-        click.echo(
-            click.style('The build was a success, continuing the release', 'green'))
+        click.echo(click.style('The build was a success, continuing the release', 'green'))
 
-    # the default behavour for versioning is commit
-    # using tag when it is explicitly configed
-    if not (config.has_option('semantic_release', 'versioning_by_tag') and
-            config.getboolean('semantic_release', 'versioning_by_tag')):
+    if config.get('semantic_release', 'version_source') == 'commit':
         set_new_version(new_version)
         commit_new_version(new_version)
     tag_new_version(new_version)
-    click.echo(
-        'Bumping with a {0} version to {1}.'.format(level_bump, new_version))
+    click.echo('Bumping with a {0} version to {1}.'.format(level_bump, new_version))
     return True
 
 

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -64,8 +64,8 @@ def version(**kwargs):
             return False
         click.echo(click.style('The build was a success, continuing the release', 'green'))
 
-    set_new_version(new_version)
-    commit_new_version(new_version)
+    # set_new_version(new_version)
+    # commit_new_version(new_version)
     tag_new_version(new_version)
     click.echo('Bumping with a {0} version to {1}.'.format(level_bump, new_version))
     return True

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -64,8 +64,12 @@ def version(**kwargs):
             return False
         click.echo(click.style('The build was a success, continuing the release', 'green'))
 
-    # set_new_version(new_version)
-    # commit_new_version(new_version)
+    # the default behavour for versioning is commit
+    # using tag when it is explicitly configed
+    if not (config.has_option('semantic_release', 'versioning_by_tag')
+        and config.getboolean('semantic_release', 'versioning_by_tag')):
+        set_new_version(new_version)
+        commit_new_version(new_version)
     tag_new_version(new_version)
     click.echo('Bumping with a {0} version to {1}.'.format(level_bump, new_version))
     return True

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -62,16 +62,18 @@ def version(**kwargs):
         if not check_build_status(owner, name, get_current_head_hash()):
             click.echo(click.style('The build has failed', 'red'))
             return False
-        click.echo(click.style('The build was a success, continuing the release', 'green'))
+        click.echo(
+            click.style('The build was a success, continuing the release', 'green'))
 
     # the default behavour for versioning is commit
     # using tag when it is explicitly configed
-    if not (config.has_option('semantic_release', 'versioning_by_tag')
-        and config.getboolean('semantic_release', 'versioning_by_tag')):
+    if not (config.has_option('semantic_release', 'versioning_by_tag') and
+            config.getboolean('semantic_release', 'versioning_by_tag')):
         set_new_version(new_version)
         commit_new_version(new_version)
     tag_new_version(new_version)
-    click.echo('Bumping with a {0} version to {1}.'.format(level_bump, new_version))
+    click.echo(
+        'Bumping with a {0} version to {1}.'.format(level_bump, new_version))
     return True
 
 
@@ -80,7 +82,8 @@ def changelog(**kwargs):
     Generates the changelog since the last release.
     """
     current_version = get_current_version()
-    log = generate_changelog(get_previous_version(current_version), current_version)
+    log = generate_changelog(
+        get_previous_version(current_version), current_version)
     for section in CHANGELOG_SECTIONS:
         if not log[section]:
             continue
@@ -102,7 +105,8 @@ def changelog(**kwargs):
                 markdown_changelog(current_version, log, header=False)
             )
         else:
-            click.echo(click.style('Missing token: cannot post changelog', 'red'), err=True)
+            click.echo(
+                click.style('Missing token: cannot post changelog', 'red'), err=True)
 
 
 def publish(**kwargs):
@@ -141,7 +145,8 @@ def publish(**kwargs):
                 markdown_changelog(new_version, log, header=False)
             )
         else:
-            click.echo(click.style('Missing token: cannot post changelog', 'red'), err=True)
+            click.echo(
+                click.style('Missing token: cannot post changelog', 'red'), err=True)
 
         click.echo(click.style('New release published', 'green'))
     else:

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -6,3 +6,4 @@ check_build_status=false
 hvcs=github
 commit_parser=semantic_release.history.angular_parser
 upload_to_pypi=true
+version_source=commit

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -3,7 +3,7 @@ import re
 import semver
 
 from ..settings import config
-from ..vcs_helpers import get_commit_log
+from ..vcs_helpers import get_commit_log, get_last_version
 from .logs import evaluate_version_bump  # noqa
 
 from .parser_angular import parse_commit_message as angular_parser  # noqa isort:skip
@@ -13,17 +13,15 @@ from .parser_tag import parse_commit_message as tag_parser  # noqa isort:skip
 def get_current_version():
     """
     Finds the current version of the package in the current working directory.
+    Check tags rather than config file. return 0.0.0 if fails
 
     :return: A string with the version number.
     """
-    filename, variable = config.get('semantic_release', 'version_variable').split(':')
-    variable = variable.strip()
-    with open(filename, 'r') as fd:
-        return re.search(
-            r'^{0}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(variable),
-            fd.read(),
-            re.MULTILINE
-        ).group(1)
+    version = get_last_version()
+    if version:
+        return version
+    else:
+        return '0.0.0'
 
 
 def get_new_version(current_version, level_bump):

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -35,8 +35,8 @@ def get_current_version_by_config_file():
             re.MULTILINE
         ).group(1)
 
-if (config.has_option('semantic_release', 'versioning_by_tag')
-        and config.getboolean('semantic_release', 'versioning_by_tag')):
+if (config.has_option('semantic_release', 'versioning_by_tag') and
+        config.getboolean('semantic_release', 'versioning_by_tag')):
     get_current_version = get_current_version_by_tag
 else:
     get_current_version = get_current_version_by_config_file

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -35,8 +35,7 @@ def get_current_version_by_config_file():
             re.MULTILINE
         ).group(1)
 
-if (config.has_option('semantic_release', 'versioning_by_tag') and
-        config.getboolean('semantic_release', 'versioning_by_tag')):
+if config.get('semantic_release', 'version_source') == 'tag':
     get_current_version = get_current_version_by_tag
 else:
     get_current_version = get_current_version_by_config_file

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -2,7 +2,7 @@ import re
 
 from ..errors import UnknownCommitMessageStyleError
 from ..settings import config, current_commit_parser
-from ..vcs_helpers import get_commit_log
+from ..vcs_helpers import get_commit_log, get_version_from_tag
 
 LEVELS = {
     1: 'patch',
@@ -31,11 +31,11 @@ def evaluate_version_bump(current_version, force=None):
 
     changes = []
     commit_count = 0
-
-    for commit_message in get_commit_log('v{0}'.format(current_version)):
-        if current_version in commit_message:
-            break
-
+    # we have to first find our the version hash tagged correspondingly
+    version_hash = get_version_from_tag('v{0}'.format(current_version))
+    for commit_message in get_commit_log(version_hash):
+        # since changed the version as tag, it won't show up in commit message
+        # so we could simply get all commits in this version
         try:
             message = current_commit_parser()(commit_message)
             changes.append(message[0])

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -2,7 +2,7 @@ import re
 
 from ..errors import UnknownCommitMessageStyleError
 from ..settings import config, current_commit_parser
-from ..vcs_helpers import get_commit_log, get_version_from_tag
+from ..vcs_helpers import get_commit_log
 
 LEVELS = {
     1: 'patch',
@@ -32,31 +32,17 @@ def evaluate_version_bump(current_version, force=None):
     changes = []
     commit_count = 0
 
-    if (config.has_option('semantic_release', 'versioning_by_tag') and
-            config.getboolean('semantic_release', 'versioning_by_tag')):
-        # we have to first find our the version hash tagged correspondingly
-        version_hash = get_version_from_tag('v{0}'.format(current_version))
-        for commit_message in get_commit_log(version_hash):
-            # since changed the version as tag, it won't show up in commit message
-            # so we could simply get all commits in this version
-            try:
-                message = current_commit_parser()(commit_message)
-                changes.append(message[0])
-            except UnknownCommitMessageStyleError:
-                pass
+    for commit_message in get_commit_log('v{0}'.format(current_version)):
+        if (current_version in commit_message and
+                config.get('semantic_release', 'version_source') == 'commit'):
+            break
+        try:
+            message = current_commit_parser()(commit_message)
+            changes.append(message[0])
+        except UnknownCommitMessageStyleError:
+            pass
 
-            commit_count += 1
-    else:
-        for commit_message in get_commit_log('v{0}'.format(current_version)):
-            if current_version in commit_message:
-                break
-            try:
-                message = current_commit_parser()(commit_message)
-                changes.append(message[0])
-            except UnknownCommitMessageStyleError:
-                pass
-
-            commit_count += 1
+        commit_count += 1
 
     if changes:
         level = max(changes)

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -32,8 +32,8 @@ def evaluate_version_bump(current_version, force=None):
     changes = []
     commit_count = 0
 
-    if (config.has_option('semantic_release', 'versioning_by_tag')
-            and config.getboolean('semantic_release', 'versioning_by_tag')):
+    if (config.has_option('semantic_release', 'versioning_by_tag') and
+            config.getboolean('semantic_release', 'versioning_by_tag')):
         # we have to first find our the version hash tagged correspondingly
         version_hash = get_version_from_tag('v{0}'.format(current_version))
         for commit_message in get_commit_log(version_hash):

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -19,6 +19,23 @@ def get_commit_log(from_rev=None):
         yield commit.message
 
 
+def get_last_version():
+    '''
+    return last version from repo tags
+
+    :return: a string contains version number
+    '''
+    tags = len(repo.tags)
+    for i in range(tags - 1, -1, -1):
+        if re.match('v\d+\.\d+\.\d+', repo.tags[i].name):
+            return repo.tags[i].name[1:]
+
+
+def get_version_from_tag(tag_name):
+    for i in repo.tags:
+        if i.name == tag_name:
+            return i.commit.hexsha
+
 def get_repository_owner_and_name():
     """
     Checks the origin remote to get the owner and name of the remote repository.
@@ -47,7 +64,8 @@ def commit_new_version(version):
 
     :param version: The version number to be used in the commit message
     """
-    repo.git.add(config.get('semantic_release', 'version_variable').split(':')[0])
+    repo.git.add(
+        config.get('semantic_release', 'version_variable').split(':')[0])
     return repo.git.commit(m=version, author="semantic-release <semantic-release>")
 
 

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -25,16 +25,17 @@ def get_last_version():
 
     :return: a string contains version number
     '''
-    tags = len(repo.tags)
-    for i in range(tags - 1, -1, -1):
-        if re.match('v\d+\.\d+\.\d+', repo.tags[i].name):
-            return repo.tags[i].name[1:]
+    for i in sorted(repo.tags, key=lambda x: x.commit.committed_date,
+                    reverse=True):
+        if re.match('v\d+\.\d+\.\d+', i.name):
+            return i.name[1:]
 
 
 def get_version_from_tag(tag_name):
     for i in repo.tags:
         if i.name == tag_name:
             return i.commit.hexsha
+
 
 def get_repository_owner_and_name():
     """

--- a/tests/parsers/test_angular.py
+++ b/tests/parsers/test_angular.py
@@ -24,7 +24,8 @@ def test_parser_return_correct_bump_level():
     )
     assert angular_parser('feat(parser): Add emoji parser')[0] == 2
     assert angular_parser('fix(parser): Fix regex in angular parser')[0] == 1
-    assert angular_parser('test(parser): Add a test for angular parser')[0] == 0
+    assert angular_parser(
+        'test(parser): Add a test for angular parser')[0] == 0
 
 
 def test_parser_return_type_from_commit_message():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,7 +242,7 @@ def test_publish_should_call_functions(mocker, runner):
     mock_version.assert_called_once_with(
         noop=False, post=False, force_level=None)
     mock_log.assert_called_once_with(
-        'KenMercusLai', 'python-semantic-release', '2.0.0', 'CHANGES')
+        u'relekang', 'python-semantic-release', '2.0.0', 'CHANGES')
     mock_checkout.assert_called_once_with('master')
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,12 +41,11 @@ def test_version_by_commit_should_call_correct_functions(mocker, runner):
 
 
 def test_version_by_tag_should_call_correct_functions(mocker, runner):
-    def config_file_path(*args):
-        if args[0] == 'semantic_release' and args[1] == 'versioning_by_tag':
-            return True
-        return False
-    mocker.patch('semantic_release.cli.config.getboolean', config_file_path)
-    mocker.patch('semantic_release.cli.config.has_option', lambda *x: True)
+    # def config_file_path(*args):
+    #     if args[0] == 'semantic_release' and args[1] == 'version_source':
+    #         return True
+    #     return False
+    # mocker.patch('semantic_release.cli.config.getboolean', config_file_path)
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
     mock_new_version = mocker.patch(
         'semantic_release.cli.get_new_version', return_value='2.0.0')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,9 +48,6 @@ def test_version_by_tag_should_call_correct_functions(mocker, runner):
     mocker.patch('semantic_release.cli.config.getboolean', config_file_path)
     mocker.patch('semantic_release.cli.config.has_option', lambda *x: True)
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
-    mock_commit_new_version = mocker.patch(
-        'semantic_release.cli.commit_new_version')
-    mock_set_new_version = mocker.patch('semantic_release.cli.set_new_version')
     mock_new_version = mocker.patch(
         'semantic_release.cli.get_new_version', return_value='2.0.0')
     mock_evaluate_bump = mocker.patch('semantic_release.cli.evaluate_version_bump',
@@ -160,6 +157,7 @@ def test_version_by_commit_check_build_status_succeeds(mocker, runner):
     assert mock_tag_new_version.called
     assert result.exit_code == 0
 
+
 def test_version_by_tag_check_build_status_succeeds(mocker, runner):
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: True)
     mocker.patch('semantic_release.cli.config.has_option', lambda *x: True)
@@ -168,8 +166,6 @@ def test_version_by_tag_check_build_status_succeeds(mocker, runner):
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
     mocker.patch(
         'semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
-    mock_commit_new = mocker.patch('semantic_release.cli.commit_new_version')
-    mock_set_new = mocker.patch('semantic_release.cli.set_new_version')
     result = runner.invoke(main, ['version'])
     assert mock_check_build_status.called
     assert mock_tag_new_version.called

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,16 +12,19 @@ def runner():
 def test_main_should_call_correct_function(mocker, runner):
     mock_version = mocker.patch('semantic_release.cli.version')
     result = runner.invoke(main, ['version'])
-    mock_version.assert_called_once_with(noop=False, post=False, force_level=None)
+    mock_version.assert_called_once_with(
+        noop=False, post=False, force_level=None)
     assert result.exit_code == 0
 
 
-def test_version_should_call_correct_functions(mocker, runner):
+def test_version_by_commit_should_call_correct_functions(mocker, runner):
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: False)
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
-    mock_commit_new_version = mocker.patch('semantic_release.cli.commit_new_version')
+    mock_commit_new_version = mocker.patch(
+        'semantic_release.cli.commit_new_version')
     mock_set_new_version = mocker.patch('semantic_release.cli.set_new_version')
-    mock_new_version = mocker.patch('semantic_release.cli.get_new_version', return_value='2.0.0')
+    mock_new_version = mocker.patch(
+        'semantic_release.cli.get_new_version', return_value='2.0.0')
     mock_evaluate_bump = mocker.patch('semantic_release.cli.evaluate_version_bump',
                                       return_value='major')
     mock_current_version = mocker.patch('semantic_release.cli.get_current_version',
@@ -37,10 +40,37 @@ def test_version_should_call_correct_functions(mocker, runner):
     assert result.exit_code == 0
 
 
+def test_version_by_tag_should_call_correct_functions(mocker, runner):
+    def config_file_path(*args):
+        if args[0] == 'semantic_release' and args[1] == 'versioning_by_tag':
+            return True
+        return False
+    mocker.patch('semantic_release.cli.config.getboolean', config_file_path)
+    mocker.patch('semantic_release.cli.config.has_option', lambda *x: True)
+    mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
+    mock_commit_new_version = mocker.patch(
+        'semantic_release.cli.commit_new_version')
+    mock_set_new_version = mocker.patch('semantic_release.cli.set_new_version')
+    mock_new_version = mocker.patch(
+        'semantic_release.cli.get_new_version', return_value='2.0.0')
+    mock_evaluate_bump = mocker.patch('semantic_release.cli.evaluate_version_bump',
+                                      return_value='major')
+    mock_current_version = mocker.patch('semantic_release.cli.get_current_version',
+                                        return_value='1.2.3')
+
+    result = runner.invoke(main, ['version'])
+    mock_current_version.assert_called_once_with()
+    mock_evaluate_bump.assert_called_once_with('1.2.3', None)
+    mock_new_version.assert_called_once_with('1.2.3', 'major')
+    mock_tag_new_version.assert_called_once_with('2.0.0')
+    assert result.exit_code == 0
+
+
 def test_force_major(mocker, runner):
     mock_version = mocker.patch('semantic_release.cli.version')
     result = runner.invoke(main, ['version', '--major'])
-    mock_version.assert_called_once_with(noop=False, post=False, force_level='major')
+    mock_version.assert_called_once_with(
+        noop=False, post=False, force_level='major')
     assert mock_version.call_args_list[0][1]['force_level'] == 'major'
     assert result.exit_code == 0
 
@@ -48,7 +78,8 @@ def test_force_major(mocker, runner):
 def test_force_minor(mocker, runner):
     mock_version = mocker.patch('semantic_release.cli.version')
     result = runner.invoke(main, ['version', '--minor'])
-    mock_version.assert_called_once_with(noop=False, post=False, force_level='minor')
+    mock_version.assert_called_once_with(
+        noop=False, post=False, force_level='minor')
     assert mock_version.call_args_list[0][1]['force_level'] == 'minor'
     assert result.exit_code == 0
 
@@ -56,7 +87,8 @@ def test_force_minor(mocker, runner):
 def test_force_patch(mocker, runner):
     mock_version = mocker.patch('semantic_release.cli.version')
     result = runner.invoke(main, ['version', '--patch'])
-    mock_version.assert_called_once_with(noop=False, post=False, force_level='patch')
+    mock_version.assert_called_once_with(
+        noop=False, post=False, force_level='patch')
     assert mock_version.call_args_list[0][1]['force_level'] == 'patch'
     assert result.exit_code == 0
 
@@ -65,7 +97,8 @@ def test_noop_mode(mocker, runner):
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
     mock_set_new = mocker.patch('semantic_release.cli.commit_new_version')
     mock_commit_new = mocker.patch('semantic_release.cli.set_new_version')
-    mocker.patch('semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
+    mocker.patch(
+        'semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
     result = runner.invoke(main, ['version', '--noop'])
     assert not mock_set_new.called
     assert not mock_commit_new.called
@@ -75,9 +108,11 @@ def test_noop_mode(mocker, runner):
 
 def test_version_no_change(mocker, runner):
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
-    mock_commit_new_version = mocker.patch('semantic_release.cli.commit_new_version')
+    mock_commit_new_version = mocker.patch(
+        'semantic_release.cli.commit_new_version')
     mock_set_new_version = mocker.patch('semantic_release.cli.set_new_version')
-    mock_new_version = mocker.patch('semantic_release.cli.get_new_version', return_value='1.2.3')
+    mock_new_version = mocker.patch(
+        'semantic_release.cli.get_new_version', return_value='1.2.3')
     mock_evaluate_bump = mocker.patch('semantic_release.cli.evaluate_version_bump',
                                       return_value=None)
     mock_current_version = mocker.patch('semantic_release.cli.get_current_version',
@@ -99,7 +134,8 @@ def test_version_check_build_status_fails(mocker, runner):
     mock_commit_new = mocker.patch('semantic_release.cli.commit_new_version')
     mock_set_new = mocker.patch('semantic_release.cli.set_new_version')
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: True)
-    mocker.patch('semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
+    mocker.patch(
+        'semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
     result = runner.invoke(main, ['version'])
     assert mock_check_build_status.called
     assert not mock_set_new.called
@@ -108,12 +144,13 @@ def test_version_check_build_status_fails(mocker, runner):
     assert result.exit_code == 0
 
 
-def test_version_check_build_status_succeeds(mocker, runner):
+def test_version_by_commit_check_build_status_succeeds(mocker, runner):
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: True)
     mock_check_build_status = mocker.patch('semantic_release.cli.check_build_status',
                                            return_value=True)
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
-    mocker.patch('semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
+    mocker.patch(
+        'semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
     mock_commit_new = mocker.patch('semantic_release.cli.commit_new_version')
     mock_set_new = mocker.patch('semantic_release.cli.set_new_version')
     result = runner.invoke(main, ['version'])
@@ -123,12 +160,29 @@ def test_version_check_build_status_succeeds(mocker, runner):
     assert mock_tag_new_version.called
     assert result.exit_code == 0
 
+def test_version_by_tag_check_build_status_succeeds(mocker, runner):
+    mocker.patch('semantic_release.cli.config.getboolean', lambda *x: True)
+    mocker.patch('semantic_release.cli.config.has_option', lambda *x: True)
+    mock_check_build_status = mocker.patch('semantic_release.cli.check_build_status',
+                                           return_value=True)
+    mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
+    mocker.patch(
+        'semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
+    mock_commit_new = mocker.patch('semantic_release.cli.commit_new_version')
+    mock_set_new = mocker.patch('semantic_release.cli.set_new_version')
+    result = runner.invoke(main, ['version'])
+    assert mock_check_build_status.called
+    assert mock_tag_new_version.called
+    assert result.exit_code == 0
+
 
 def test_version_check_build_status_not_called_if_disabled(mocker, runner):
-    mock_check_build_status = mocker.patch('semantic_release.cli.check_build_status')
+    mock_check_build_status = mocker.patch(
+        'semantic_release.cli.check_build_status')
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: False)
     mocker.patch('semantic_release.cli.tag_new_version', None)
-    mocker.patch('semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
+    mocker.patch(
+        'semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
     mocker.patch('semantic_release.cli.commit_new_version', None)
     mocker.patch('semantic_release.cli.set_new_version', None)
     runner.invoke(main, ['version'])
@@ -142,7 +196,8 @@ def test_publish_should_not_upload_to_pypi_if_option_is_false(mocker, runner):
     mocker.patch('semantic_release.cli.post_changelog', lambda *x: True)
     mocker.patch('semantic_release.cli.push_new_version', lambda *x: True)
     mocker.patch('semantic_release.cli.version', lambda: True)
-    mocker.patch('semantic_release.cli.markdown_changelog', lambda *x, **y: 'CHANGES')
+    mocker.patch(
+        'semantic_release.cli.markdown_changelog', lambda *x, **y: 'CHANGES')
     mocker.patch('semantic_release.cli.get_new_version', lambda *x: '2.0.0')
     mocker.patch('semantic_release.cli.check_token', lambda: True)
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: False)
@@ -159,9 +214,11 @@ def test_publish_should_do_nothing_when_version_fails(mocker, runner):
     mock_upload = mocker.patch('semantic_release.cli.upload_to_pypi')
     mock_push = mocker.patch('semantic_release.cli.push_new_version')
     mock_ci_check = mocker.patch('semantic_release.ci_checks.check')
-    mock_version = mocker.patch('semantic_release.cli.version', return_value=False)
+    mock_version = mocker.patch(
+        'semantic_release.cli.version', return_value=False)
     result = runner.invoke(main, ['publish'])
-    mock_version.assert_called_once_with(noop=False, post=False, force_level=None)
+    mock_version.assert_called_once_with(
+        noop=False, post=False, force_level=None)
     assert not mock_push.called
     assert not mock_upload.called
     assert not mock_log.called
@@ -186,13 +243,17 @@ def test_publish_should_call_functions(mocker, runner):
     assert mock_ci_check.called
     assert mock_push.called
     assert mock_pypi.called
-    mock_version.assert_called_once_with(noop=False, post=False, force_level=None)
-    mock_log.assert_called_once_with('relekang', 'python-semantic-release', '2.0.0', 'CHANGES')
+    mock_version.assert_called_once_with(
+        noop=False, post=False, force_level=None)
+    mock_log.assert_called_once_with(
+        'KenMercusLai', 'python-semantic-release', '2.0.0', 'CHANGES')
     mock_checkout.assert_called_once_with('master')
 
 
 def test_changelog_should_call_functions(mocker, runner):
-    mock_changelog = mocker.patch('semantic_release.cli.changelog', return_value=True)
+    mock_changelog = mocker.patch(
+        'semantic_release.cli.changelog', return_value=True)
     result = runner.invoke(main, ['changelog'])
     assert result.exit_code == 0
-    mock_changelog.assert_called_once_with(noop=False, post=False, force_level=None)
+    mock_changelog.assert_called_once_with(
+        noop=False, post=False, force_level=None)

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -38,7 +38,7 @@ def test_push_new_version(mock_git):
 
 
 def test_get_repository_owner_and_name():
-    assert get_repository_owner_and_name()[0] == 'KenMercusLai'
+    assert get_repository_owner_and_name()[0] == 'relekang'
     assert get_repository_owner_and_name()[1] == 'python-semantic-release'
 
 

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -38,7 +38,7 @@ def test_push_new_version(mock_git):
 
 
 def test_get_repository_owner_and_name():
-    assert get_repository_owner_and_name()[0] == 'relekang'
+    assert get_repository_owner_and_name()[0] == 'KenMercusLai'
     assert get_repository_owner_and_name()[1] == 'python-semantic-release'
 
 


### PR DESCRIPTION
I changed the behaviours of finding current version and versioning

1. original way was using configed file to track version, I think using tag would be more straight forward. it returns 0.0.0 as default when it fails to find any version tag
2. instead of changing file content, I simply use tag to tract commits. I'm not sure this is a good way of versioning since I'm not a professional programmer.