### PR TITLE
Add support to finding previous version from tags if not using commit messages

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -78,8 +78,13 @@ def changelog(**kwargs):
     Generates the changelog since the last release.
     """
     current_version = get_current_version()
-    log = generate_changelog(
-        get_previous_version(current_version), current_version)
+    if current_version is None:
+        raise Exception("Unable to get the current verison."
+                        " Make sure semantic_release.version_variable "
+                        "is setup correctly")
+    previous_version = get_previous_version(current_version)
+
+    log = generate_changelog(previous_version,  current_version)
     for section in CHANGELOG_SECTIONS:
         if not log[section]:
             continue

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -69,8 +69,11 @@ def get_previous_version(version):
             continue
 
         if found_version:
-            if re.match(r'v?\d+.\d+.\d+', commit_message):
-                return commit_message.replace('v', '').strip()
+            matches = re.match(r'v?(\d+.\d+.\d+)', commit_message)
+            if matches:
+                return matches.group(1).strip()
+
+    return get_last_version([version, 'v{}'.format(version)])
 
 
 def set_new_version(new_version):

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -1,6 +1,6 @@
 import re
 
-from git import GitCommandError, Repo
+from git import GitCommandError, TagObject, Repo
 
 from .errors import GitError
 from .settings import config
@@ -19,14 +19,18 @@ def get_commit_log(from_rev=None):
         yield (commit.hexsha, commit.message)
 
 
-def get_last_version():
+def get_last_version(skipTags=[]):
     """
     return last version from repo tags
 
     :return: a string contains version number
     """
-    for i in sorted(repo.tags, key=lambda x: x.commit.committed_date, reverse=True):
+    for i in sorted(repo.tags, reverse=True, key=lambda x: x.tag.tagged_date
+                                                 if isinstance(x.commit,TagObject)
+                                                 else x.commit.committed_date):
         if re.match('v\d+\.\d+\.\d+', i.name):
+            if i.name in skipTags:
+                continue
             return i.name[1:]
 
 


### PR DESCRIPTION
I was converting an older project, and having a bit of a hard time. Took me a while the
system was looking specifically for a commit with a message of "v\d+.\d+.\d+"

This allows annotated tags with version names to work as well