### PR TITLE
Update Twine

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,6 @@ click==6.2
 gitpython==1.0.1
 invoke==0.11.1
 semver==2.2.1
-twine==1.5.0
+twine==1.9.1
 requests==2.9.1
 wheel


### PR DESCRIPTION
The publishing API is under development and older versions of Twine have problems to deal with newer versions of the API. Namely the logic of register/upload has changed (it was simplified).