### PR TITLE
fix: Fix broken uploading code

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,6 @@ click==6.2
 gitpython==1.0.1
 invoke==0.11.1
 semver==2.2.1
-twine==1.5.0
+twine==1.9.1
 requests==2.9.1
 wheel

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -125,12 +125,6 @@ def publish(**kwargs):
             name=name
         )
 
-        if config.getboolean('semantic_release', 'upload_to_pypi'):
-            upload_to_pypi(
-                username=os.environ.get('PYPI_USERNAME'),
-                password=os.environ.get('PYPI_PASSWORD'),
-            )
-
         if check_token():
             click.echo('Updating changelog')
             try:
@@ -143,6 +137,12 @@ def publish(**kwargs):
                 )
             except GitError:
                 click.echo(click.style('Posting changelog failed.', 'red'), err=True)
+
+        if config.getboolean('semantic_release', 'upload_to_pypi'):
+            upload_to_pypi(
+                username=os.environ.get('PYPI_USERNAME'),
+                password=os.environ.get('PYPI_PASSWORD'),
+            )
 
         else:
             click.echo(

--- a/semantic_release/pypi.py
+++ b/semantic_release/pypi.py
@@ -17,6 +17,11 @@ def upload_to_pypi(dists='sdist bdist_wheel', username=None, password=None):
         username=username,
         password=password,
         comment=None,
-        sign_with='gpg'
+        sign_with='gpg',
+        config_file="~/.pypirc",
+        skip_existing=False,
+        cert=None,
+        client_cert=None,
+        repository_url=None,
     )
     run('rm -rf build dist')


### PR DESCRIPTION
This fixes broken uploading due to the new PyPI API by upgrading Twine to the latest version.

It also reorders operations so that PyPI uploading is the last step, as it's the easiest to then do manually if it breaks again.