### PR TITLE
fix: update call to upload to work with twine 1.9.1

### DIFF
--- a/semantic_release/pypi.py
+++ b/semantic_release/pypi.py
@@ -17,6 +17,11 @@ def upload_to_pypi(dists='sdist bdist_wheel', username=None, password=None):
         username=username,
         password=password,
         comment=None,
-        sign_with='gpg'
+        sign_with='gpg',
+        config_file='~/.pypirc',
+        skip_existing=False,
+        cert=None,
+        client_cert=None,
+        repository_url=None
     )
     run('rm -rf build dist')

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -22,7 +22,12 @@ class PypiTests(TestCase):
             username=None,
             password=None,
             comment=None,
-            sign_with='gpg'
+            sign_with='gpg',
+            config_file='~/.pypirc',
+            skip_existing=False,
+            cert=None,
+            client_cert=None,
+            repository_url=None
         )
 
     @mock.patch('semantic_release.pypi.run')


### PR DESCRIPTION
Fixes current broken master. 
See discussion in: https://github.com/relekang/python-semantic-release/pull/69