### PR TITLE
Fix: error when not in git repository

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -5,13 +5,13 @@ from git import GitCommandError, Repo
 from .errors import GitError
 from .settings import config
 
-repo = Repo('.git', search_parent_directories=True)
-
 
 def get_commit_log(from_rev=None):
     """
     Yields all commit messages from last to first.
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     rev = None
     if from_rev:
         rev = '...{from_rev}'.format(from_rev=from_rev)
@@ -25,12 +25,16 @@ def get_last_version():
 
     :return: a string contains version number
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     for i in sorted(repo.tags, key=lambda x: x.commit.committed_date, reverse=True):
         if re.match('v\d+\.\d+\.\d+', i.name):
             return i.name[1:]
 
 
 def get_version_from_tag(tag_name):
+    repo = Repo('.git', search_parent_directories=True)
+
     for i in repo.tags:
         if i.name == tag_name:
             return i.commit.hexsha
@@ -42,6 +46,8 @@ def get_repository_owner_and_name():
 
     :return: a tuple of the owner and name
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     url = repo.remote('origin').url
     parts = re.search(r'([^/:]+)/([^/]+).git$', url)
 
@@ -54,6 +60,8 @@ def get_current_head_hash():
 
     :return: a string with the commit hash.
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     return repo.head.commit.name_rev.split(' ')[0]
 
 
@@ -64,6 +72,8 @@ def commit_new_version(version):
 
     :param version: The version number to be used in the commit message
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     repo.git.add(
         config.get('semantic_release', 'version_variable').split(':')[0])
     return repo.git.commit(m=version, author="semantic-release <semantic-release>")
@@ -75,6 +85,8 @@ def tag_new_version(version):
 
     :param version: The version number used in the tag as a string.
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     return repo.git.tag('-a', 'v{0}'.format(version), m='v{0}'.format(version))
 
 
@@ -85,6 +97,8 @@ def push_new_version(gh_token=None, owner=None, name=None):
     :param owner: Organisation or user that owns the repository.
     :param name: Name of repository.
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     server = 'origin'
     if gh_token:
         server = 'https://{token}@{repo}'.format(
@@ -108,4 +122,6 @@ def checkout(branch):
 
     :param branch: The branch to checkout.
     """
+    repo = Repo('.git', search_parent_directories=True)
+
     return repo.git.checkout(branch)


### PR DESCRIPTION
Fix an error when the program was run in a non-git repository. It would not allow the help options to be run.

@relekang I know you wanted to put this `repo = Repo('.git', search_parent_directories=True)` line in it's own function. However that just adds unnecessary overhead and furthermore it does not lead to cleaner code.