### PR TITLE
chore: remove python2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,6 @@
 version: 2
 
 jobs:
-  flake8:
-    docker:
-      - image: circleci/python:3.6
-
-    steps:
-      - checkout
-      - run: sudo pip install tox
-      - restore_cache:
-         keys:
-           - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-      - run: tox --notest
-      - save_cache:
-         key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-         paths:
-           - .tox
-      - run: tox -e flake8
-
-  isort:
-    docker:
-      - image: circleci/python:3.6
-
-    steps:
-      - checkout
-      - run: sudo pip install tox
-      - restore_cache:
-         keys:
-           - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-      - run: tox --notest
-      - save_cache:
-         key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-         paths:
-           - .tox
-      - run: tox -e isort
-
   tests:
     docker:
       - image: circleci/python:3.6
@@ -50,15 +16,11 @@ jobs:
          key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
          paths:
            - .tox
-      - run: tox -e py2-tests
-      - run: tox -e py3-tests
-      - run: tox -e coverage
+      - run: tox
 
 workflows:
   version: 2
 
   build:
     jobs:
-      - flake8
-      - isort
       - tests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,10 @@
 
 # test-tools
 coverage
+isort
+flake8
 pytest
+pytest-cov
 pytest-xdist
 pytest-mock
 tox==2.3.1

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -1,13 +1,9 @@
+import configparser
 import importlib
 import os
 from os import getcwd
 
 from .errors import ImproperConfigurationError
-
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
 
 
 def _config():

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ setup(
     include_package_data=True,
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,10 @@
 [tox]
-envlist =
-    flake8,
-    isort,
-    {py2,py3}-tests
-    coverage
+envlist = py3
 skipsdist = True
 
 [testenv]
-basepython =
-  flake8: python3
-  isort: python3
-  coverage: python3
-  py2: python2
-  py3: python3
-deps =
-    tests: -r{toxinidir}/requirements/dev.txt
-    flake8: flake8
-    isort: isort
-    coverage: coverage
-passenv = CI
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}
-    TESTING = True
+deps = -r{toxinidir}/requirements/dev.txt
 commands =
-    tests: coverage run -p --source=semantic_release -m py.test -v tests
-    py3-tests: coverage combine
-    flake8: flake8
-    isort: isort -c -rc semantic_release tests
-    coverage: coverage report
-    coverage: coverage xml
+    flake8
+    isort -c -rc semantic_release tests
+    py.test --cov=semantic_release --cov-report=term-missing tests/


### PR DESCRIPTION
This patch removes the `python2` support for project. Going forward it will be only `python3` compatible which provides multiple advantages such as cleaner syntax, etc. Also this significantly improves the `tox` testing.