### PR TITLE
fix: Never uploading existing to pypi

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -151,9 +151,7 @@ def publish(**kwargs):
         if config.getboolean('semantic_release', 'upload_to_pypi'):
             upload_to_pypi(
                 username=os.environ.get('PYPI_USERNAME'),
-                password=os.environ.get('PYPI_PASSWORD'),
-                # We are retrying, so we don't want errors for files that are already on PyPI.
-                skip_existing=retry,
+                password=os.environ.get('PYPI_PASSWORD')
             )
 
         if check_token():

--- a/semantic_release/pypi.py
+++ b/semantic_release/pypi.py
@@ -2,7 +2,7 @@ from invoke import run
 from twine.commands import upload as twine_upload
 
 
-def upload_to_pypi(dists='sdist bdist_wheel', username=None, password=None, skip_existing=False):
+def upload_to_pypi(dists='sdist bdist_wheel', username=None, password=None):
     """
     Creates the wheel and uploads to pypi with twine.
 
@@ -19,7 +19,7 @@ def upload_to_pypi(dists='sdist bdist_wheel', username=None, password=None, skip
         comment=None,
         sign_with='gpg',
         config_file='~/.pypirc',
-        skip_existing=skip_existing,
+        skip_existing=True,
         cert=None,
         client_cert=None,
         repository_url=None

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -24,7 +24,7 @@ class PypiTests(TestCase):
             comment=None,
             sign_with='gpg',
             config_file='~/.pypirc',
-            skip_existing=False,
+            skip_existing=True,
             cert=None,
             client_cert=None,
             repository_url=None


### PR DESCRIPTION
This aims to to resolve #86. Previously, the `retry` boolean flag was directly tied to the `skip-existing` flag within twine upload step for uploading to PyPI. I believe the previous rationale for this is captured by this comment: 
https://github.com/relekang/python-semantic-release/blob/762fbcfb72f3ed269eaa1bbb8b0de433166a0a47/semantic_release/cli.py#L155

Tying `retry` to `skip_existing` misses the case where a user attempts to publish to PyPI without specifying the `retry` flag.

With these new changes, when uploading to PyPI, we will always skip attempting to upload a distribution already hosted on PyPI (which throws an error). 

If a user wants to specify the `retry` flag when attempting to upload to PyPI, then `skip_existing` is already set to true by default, so we won't attempt to upload existing files. If a user _doesn't_ explicitly specify the `retry` flag, then this change ensures that we don't attempt to upload existing files to PyPI. 

Basically, when uploading to PyPI, I don't think we ever want to upload files that already exist on PyPI.

Also, from Twine's description of the `skip_existing` flag: 

> Specify whether twine should continue uploading files if one of them already exists. This primarily supports PyPI. Other package indexes may not be supported.

So it seems like it makes sense for `skip_existing` to default to `True` when uploading to PyPI.