### PR TITLE
fix: initialize git Repo from current folder

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -45,7 +45,13 @@ def version(**kwargs):
         click.echo('Retrying publication of the same version...')
     else:
         click.echo('Creating new version..')
-    current_version = get_current_version()
+
+    try:
+        current_version = get_current_version()
+    except GitError as e:
+        click.echo(click.style(str(e), 'red'), err=True)
+        return False
+
     click.echo('Current version: {0}'.format(current_version))
     level_bump = evaluate_version_bump(current_version, kwargs['force_level'])
     new_version = get_new_version(current_version, level_bump)


### PR DESCRIPTION
This allows to run the program also from inner repository folders

The problem is in the call to `Repo` constructor which should get `'.'` for the current folder and not `'.git'`.

The current version of the code, from within other functions of this module, never checks `repo` was actually initialized. This lead to a number of other problems for which we'd probably like to show a nice error message too.
See for example this one:

```
:~/tmp$ semantic-release version --noop
Creating new version..
Traceback (most recent call last):
  File "/home/luca/.local/bin/semantic-release", line 11, in <module>
    load_entry_point('python-semantic-release', 'console_scripts', 'semantic-release')()
  File "/home/luca/.local/lib/python3.4/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/luca/.local/lib/python3.4/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/luca/.local/lib/python3.4/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/luca/.local/lib/python3.4/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/luca/.local/lib/python3.4/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/luca/Projects/python-semantic-release/semantic_release/cli.py", line 208, in cmd_version
    return version(**kwargs)
  File "/home/luca/Projects/python-semantic-release/semantic_release/cli.py", line 48, in version
    current_version = get_current_version()
  File "/home/luca/Projects/python-semantic-release/semantic_release/history/__init__.py", line 41, in get_current_version
    return get_current_version_by_tag()
  File "/home/luca/Projects/python-semantic-release/semantic_release/history/__init__.py", line 20, in get_current_version_by_tag
    version = get_last_version()
  File "/home/luca/Projects/python-semantic-release/semantic_release/vcs_helpers.py", line 39, in get_last_version
    for i in sorted(repo.tags, reverse=True, key=version_finder):
AttributeError: 'NoneType' object has no attribute 'tags'
```
This is due to try accessing `repo.tags` when `repo is None`.
To solve this other problem, I've added a sanity check in every function using `repo`: in case it is not correctly initialized it throws a `GitError` with a nice messge.

To complete the nice error reporting through the CLI this requires some actual catching, for which I added a single example [here](https://github.com/splendido/python-semantic-release/blob/splendido-fix-repo-init/semantic_release/cli.py#L49-L53) so that the above error now looks like this:

```
~/tmp$ semantic-release version --noop
Creating new version..
Not in a valid git repository
```

Please feel free to add more checks like the above one where you think they fit.

also, but minor, I've made a bit of linting to the module code.