### PR TITLE
Typo, link broken

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ to adhere to the `angular commit guidelines`_. If you are unsure how to describe
 Just try and ask in your pr, or ask on gitter. If we think it should be something else or there is a
 pull-request without tags we will help out in adding or changing them.
 
-.. _angular commit guidelins: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
+.. _angular commit guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
 
 Releases
 ~~~~~~~~


### PR DESCRIPTION
Change `.. _angular commit guidelins:` to `.. _angular commit guidelines:`