### PR TITLE
Change Dependancies on Requests

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,5 +3,5 @@ gitpython==2.1.10
 invoke==0.11.1
 semver==2.2.1
 twine==1.11.0
-requests==2.9.1
+requests>=2.9.1<3
 wheel

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -6,7 +6,7 @@ from semantic_release.vcs_helpers import (checkout, commit_new_version, get_comm
                                           get_current_head_hash, get_repository_owner_and_name,
                                           push_new_version, tag_new_version)
 
-from tests import mock
+from . import mock
 
 
 @pytest.fixture

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -6,7 +6,7 @@ from semantic_release.vcs_helpers import (checkout, commit_new_version, get_comm
                                           get_current_head_hash, get_repository_owner_and_name,
                                           push_new_version, tag_new_version)
 
-from . import mock
+from tests import mock
 
 
 @pytest.fixture


### PR DESCRIPTION
The existing hard dependancy on a version of the requests library limits how this can be used.
such that for some projects it cannot be used in the same container as testing or building the application.

The changes attached should make this a bit more flexible and allow versions of requests to be used which python-semantic-release is not using yet.