### PR TITLE
Fixed setting version when using tag as source of the version string

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -85,8 +85,8 @@ def version(**kwargs):
         # No need to make changes to the repo, we're just retrying.
         return True
 
+    set_new_version(new_version)
     if config.get('semantic_release', 'version_source') == 'commit':
-        set_new_version(new_version)
         commit_new_version(new_version)
     tag_new_version(new_version)
     click.echo('Bumping with a {0} version to {1}.'.format(level_bump, new_version))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ def test_version_by_tag_should_call_correct_functions(mocker, runner):
 
     mocker.patch('semantic_release.cli.config.get', wrapped_config_get)
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: False)
+    mock_set_new_version = mocker.patch('semantic_release.cli.set_new_version')
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
     mock_new_version = mocker.patch('semantic_release.cli.get_new_version', return_value='2.0.0')
     mock_evaluate_bump = mocker.patch('semantic_release.cli.evaluate_version_bump',
@@ -63,6 +64,7 @@ def test_version_by_tag_should_call_correct_functions(mocker, runner):
     mock_current_version.assert_called_once_with()
     mock_evaluate_bump.assert_called_once_with('1.2.3', None)
     mock_new_version.assert_called_once_with('1.2.3', 'major')
+    mock_set_new_version.assert_called_once_with('2.0.0')
     mock_tag_new_version.assert_called_once_with('2.0.0')
     assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,10 +176,12 @@ def test_version_by_tag_check_build_status_succeeds(mocker, runner):
     mocker.patch('semantic_release.cli.config.getboolean', lambda *x: True)
     mock_check_build_status = mocker.patch('semantic_release.cli.check_build_status',
                                            return_value=True)
+    mock_set_new_version = mocker.patch('semantic_release.cli.set_new_version')
     mock_tag_new_version = mocker.patch('semantic_release.cli.tag_new_version')
     mocker.patch('semantic_release.cli.evaluate_version_bump', lambda *x: 'major')
     result = runner.invoke(main, ['version'])
     assert mock_check_build_status.called
+    assert mock_set_new_version.called
     assert mock_tag_new_version.called
     assert result.exit_code == 0
 


### PR DESCRIPTION
This PR answers to an issue I had earlier https://github.com/relekang/python-semantic-release/issues/97

It keeps overriding the version variable in the code even if it's not commited. This allow the building process to find it and upload the correct version on PYPI. 

I just run the relevent test for this:
```
$ pytest tests/test_cli.py -k test_version_by_tag_should_call_correct_functions
tests/test_cli.py .                                                          [100%]
===================== 1 passed, 16 deselected in 0.49 seconds ======================
```

In addition I confirm the fix works in gitlab CI environment:
```
Current version: 0.2.1
Creating new version..
Current version: 0.2.1
Bumping with a minor version to 0.3.0.
...
Uploading distributions to https://upload.pypi.org/legacy/
Uploading plup_hello-0.3.0-py3-none-any.whl
New release published
Job succeeded
```