### PR TITLE
fix(parser_angular): Fix non-match when special chars in scope

### DIFF
--- a/semantic_release/history/parser_angular.py
+++ b/semantic_release/history/parser_angular.py
@@ -6,14 +6,6 @@ from typing import Tuple
 from ..errors import UnknownCommitMessageStyleError
 from .parser_helpers import parse_text_block
 
-re_parser = re.compile(
-    r'(?P<type>feat|fix|docs|style|refactor|test|chore)'
-    r'(?:\((?P<scope>[\w _\-]+)\))?: '
-    r'(?P<subject>[^\n]+)'
-    r'(:?\n\n(?P<text>.+))?',
-    re.DOTALL
-)
-
 TYPES = {
     'feat': 'feature',
     'fix': 'fix',
@@ -23,6 +15,14 @@ TYPES = {
     'refactor': 'refactor',
     'chore': 'chore',
 }
+
+re_parser = re.compile(
+    r'(?P<type>' + '|'.join(TYPES.keys()) + ')'
+    r'(?:\((?P<scope>[^\n]+)\))?: '
+    r'(?P<subject>[^\n]+)'
+    r'(:?\n\n(?P<text>.+))?',
+    re.DOTALL
+)
 
 
 def parse_commit_message(message: str) -> Tuple[int, str, str, Tuple[str, str, str]]:

--- a/tests/parsers/test_angular.py
+++ b/tests/parsers/test_angular.py
@@ -7,7 +7,6 @@ text = 'This is an long explanatory part of a commit message. It should give ' \
        'some insight to the fix this commit adds to the codebase.'
 footer = 'Closes #400'
 
-SPECIAL_CHARS = ('12', 'feat(x_y, y.z, & z-again(prime): the reckoning): Add support for chars: !@#$%^&*()_+')
 
 def test_parser_raises_unknown_message_style():
     pytest.raises(UnknownCommitMessageStyleError, angular_parser, '')

--- a/tests/parsers/test_angular.py
+++ b/tests/parsers/test_angular.py
@@ -7,9 +7,12 @@ text = 'This is an long explanatory part of a commit message. It should give ' \
        'some insight to the fix this commit adds to the codebase.'
 footer = 'Closes #400'
 
+SPECIAL_CHARS = ('12', 'feat(x_y, y.z, & z-again(prime): the reckoning): Add support for chars: !@#$%^&*()_+')
 
 def test_parser_raises_unknown_message_style():
     pytest.raises(UnknownCommitMessageStyleError, angular_parser, '')
+    pytest.raises(UnknownCommitMessageStyleError, angular_parser,
+                  'feat(parser\n): Add new parser pattern')
 
 
 def test_parser_return_correct_bump_level():
@@ -43,6 +46,11 @@ def test_parser_return_scope_from_commit_message():
     assert angular_parser('chore(a part): ...')[2] == 'a part'
     assert angular_parser('chore(a_part): ...')[2] == 'a_part'
     assert angular_parser('chore(a-part): ...')[2] == 'a-part'
+    assert angular_parser('chore(a.part): ...')[2] == 'a.part'
+    assert angular_parser('chore(a+part): ...')[2] == 'a+part'
+    assert angular_parser('chore(a&part): ...')[2] == 'a&part'
+    assert angular_parser('chore((part)): ...')[2] == '(part)'
+    assert angular_parser('chore((p):rt): ...')[2] == '(p):rt'
 
 
 def test_parser_return_subject_from_commit_message():


### PR DESCRIPTION
Per https://github.com/relekang/python-semantic-release/issues/101, this parser fails to match when the scope contains special characters such as: `.`, `,`, `*`, `&`, etc.

This fix opens up the contents of the scope to be more broad and supplies the corresponding tests.

(It also reuses the keys from `TYPES` to be a little cleaner and easier to maintain.)