### PR TITLE
Maintain version variable formatting on bump

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -106,11 +106,10 @@ def set_new_version(new_version: str) -> bool:
         content = fr.read()
 
     content = re.sub(
-        r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable), 
-        r'\g<1>{0}\g<2>'.format(new_version)
-        , content
+        r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable),
+        r'\g<1>{0}\g<2>'.format(new_version),
+        content
     )
-
 
     with open(filename, mode='w') as fw:
         fw.write(content)

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -104,12 +104,13 @@ def set_new_version(new_version: str) -> bool:
     variable = variable.strip()
     with open(filename, mode='r') as fr:
         content = fr.read()
-
+        
     content = re.sub(
-        r'{0} ?= ?["\']\d+\.\d+(?:\.\d+)?["\']'.format(variable),
-        '{0} = \'{1}\''.format(variable, new_version),
-        content
+                r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable), 
+                r'\g<1>{0}\g<2>'.format(new_version)
+                , content
     )
+
 
     with open(filename, mode='w') as fw:
         fw.write(content)

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -91,6 +91,20 @@ def get_previous_version(version: str) -> Optional[str]:
 
     return get_last_version([version, 'v{}'.format(version)])
 
+def replace_version_string(content, variable, new_version):
+    """
+    Given the content of a file, finds the version string and updates it.
+
+    :param content: The file contents
+    :param variable: The version variable name as a string
+    :param new_version: The new version number as a string
+    :return: A string with the updated version number
+    """
+    return re.sub(
+        r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable),
+        r'\g<1>{0}\g<2>'.format(new_version),
+        content
+    )
 
 def set_new_version(new_version: str) -> bool:
     """
@@ -105,11 +119,7 @@ def set_new_version(new_version: str) -> bool:
     with open(filename, mode='r') as fr:
         content = fr.read()
 
-    content = re.sub(
-        r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable),
-        r'\g<1>{0}\g<2>'.format(new_version),
-        content
-    )
+    content = replace_version_string(content, variable, new_version)
 
     with open(filename, mode='w') as fw:
         fw.write(content)

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -91,6 +91,7 @@ def get_previous_version(version: str) -> Optional[str]:
 
     return get_last_version([version, 'v{}'.format(version)])
 
+
 def replace_version_string(content, variable, new_version):
     """
     Given the content of a file, finds the version string and updates it.
@@ -105,6 +106,7 @@ def replace_version_string(content, variable, new_version):
         r'\g<1>{0}\g<2>'.format(new_version),
         content
     )
+
 
 def set_new_version(new_version: str) -> bool:
     """

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -104,11 +104,11 @@ def set_new_version(new_version: str) -> bool:
     variable = variable.strip()
     with open(filename, mode='r') as fr:
         content = fr.read()
-        
+
     content = re.sub(
-                r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable), 
-                r'\g<1>{0}\g<2>'.format(new_version)
-                , content
+        r'({0} ?= ?["\'])\d+\.\d+(?:\.\d+)?(["\'])'.format(variable), 
+        r'\g<1>{0}\g<2>'.format(new_version)
+        , content
     )
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -81,8 +81,10 @@ class EvaluateVersionBumpTest(TestCase):
 
     def test_version_bump_maintains_formatting(self):
         self.assertEqual(replace_version_string('ver="1.2.3"', 'ver', '1.2.4'), 'ver="1.2.4"')
-        self.assertEqual(replace_version_string("version = '1.2.3'", 'version', '1.2.4'),
-            "version = '1.2.4'")
+        self.assertEqual(replace_version_string(
+                        "version = '1.2.3'", 'version', '1.2.4'),
+                        "version = '1.2.4'"
+        )
 
 
 class GenerateChangelogTests(TestCase):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -81,7 +81,8 @@ class EvaluateVersionBumpTest(TestCase):
 
     def test_version_bump_maintains_formatting(self):
         self.assertEqual(replace_version_string('ver="1.2.3"', 'ver', '1.2.4'), 'ver="1.2.4"')
-        self.assertEqual(replace_version_string("version = '1.2.3'", 'version', '1.2.4'), "version = '1.2.4'")
+        self.assertEqual(replace_version_string("version = '1.2.3'", 'version', '1.2.4'),
+            "version = '1.2.4'")
 
 
 class GenerateChangelogTests(TestCase):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -80,8 +80,8 @@ class EvaluateVersionBumpTest(TestCase):
             self.assertIsNone(evaluate_version_bump('1.1.0'))
 
     def test_version_bump_maintains_formatting(self):
-        self.assertEqual(replace_version_string('ver="1.2.3"','ver','1.2.4'), 'ver="1.2.4"')
-        self.assertEqual(replace_version_string("version = '1.2.3'",'version','1.2.4'), "version = '1.2.4'")
+        self.assertEqual(replace_version_string('ver="1.2.3"', 'ver', '1.2.4'), 'ver="1.2.4"')
+        self.assertEqual(replace_version_string("version = '1.2.3'", 'version', '1.2.4'), "version = '1.2.4'")
 
 
 class GenerateChangelogTests(TestCase):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import semantic_release
 from semantic_release.history import (evaluate_version_bump, get_current_version, get_new_version,
-                                      get_previous_version)
+                                      get_previous_version, replace_version_string)
 from semantic_release.history.logs import generate_changelog, markdown_changelog
 
 from . import mock
@@ -78,6 +78,10 @@ class EvaluateVersionBumpTest(TestCase):
 
         with mock.patch('semantic_release.history.config.getboolean', lambda *x: False):
             self.assertIsNone(evaluate_version_bump('1.1.0'))
+
+    def test_version_bump_maintains_formatting(self):
+        self.assertEqual(replace_version_string('ver="1.2.3"','ver','1.2.4'), 'ver="1.2.4"')
+        self.assertEqual(replace_version_string("version = '1.2.3'",'version','1.2.4'), "version = '1.2.4'")
 
 
 class GenerateChangelogTests(TestCase):


### PR DESCRIPTION
Small change to the way the version is written to the config file it is read from.  This allows the formatting to be the same as before semantic-release changed it.

Prior behavior
`my_version_var="1.2.3"` => `my_version_var = '1.2.4'`

New behavior
`my_version_var="1.2.3"` => `my_version_var="1.2.4"`

I am using python-semantic-release with a Julia project and this change will allow for consistent formatting in my Project.toml file where the version is maintained