### PR TITLE
chore: ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
venv is ignored in config for flake8 and isort.
Should be ignored in git as well.