### PR TITLE
fix(vcs): allow cli to be run from subdirectory

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -1,6 +1,8 @@
 """VCS Helpers
 """
+import os
 import re
+from pathlib import PurePath
 from typing import Optional, Tuple
 
 import ndebug
@@ -112,7 +114,12 @@ def commit_new_version(version: str):
     check_repo()
     commit_message = config.get('semantic_release', 'commit_message')
     message = '{0}\n\n{1}'.format(version, commit_message)
-    repo.git.add(config.get('semantic_release', 'version_variable').split(':')[0])
+
+    version_file = config.get('semantic_release', 'version_variable').split(':')[0]
+    # get actual path to filename, to allow running cmd from subdir of git root
+    version_filepath = PurePath(os.getcwd(), version_file).relative_to(repo.working_dir)
+
+    repo.git.add(str(version_filepath))
     return repo.git.commit(m=message, author="semantic-release <semantic-release>")
 
 


### PR DESCRIPTION
Currently, running a semantic-release command from a subdirectory of the repo (e.g. in monorepos) will fail, during the commit phase, as it will try to add the file relative to the repository root. This makes it add the file relative to the cwd.

Might be related to https://github.com/relekang/python-semantic-release/issues/66