### PR TITLE
Fix isort and circleci badge

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -90,6 +90,6 @@ To test your modifications locally:
     tox
 
 
-.. |Build status| image:: https://circleci.com/gh/relekang/python-semantic-release.svg?style=svg
-    :target: https://circleci.com/gh/relekang/python-semantic-release
+.. |Build status| image:: https://circleci.com/gh/relekang/python-semantic-release/tree/master.svg?style=svg
+    :target: https://circleci.com/gh/relekang/python-semantic-release/tree/master
 .. |PyPI version| image:: https://badge.fury.io/py/python-semantic-release.svg

--- a/semantic_release/__init__.py
+++ b/semantic_release/__init__.py
@@ -3,8 +3,8 @@
 __version__ = '4.1.1'
 
 
-from .errors import (SemanticReleaseBaseError, ImproperConfigurationError,  # noqa
-                     UnknownCommitMessageStyleError)  # noqa
+from .errors import UnknownCommitMessageStyleError  # noqa; noqa
+from .errors import ImproperConfigurationError, SemanticReleaseBaseError
 
 
 def setup_hook(argv: list):

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -2,14 +2,15 @@
 """
 import re
 from typing import Optional
-import semver
 
 import ndebug
+import semver
 
+from ..errors import ImproperConfigurationError
 from ..settings import config
 from ..vcs_helpers import get_commit_log, get_last_version
 from .logs import evaluate_version_bump  # noqa
-from ..errors import ImproperConfigurationError
+
 from .parser_angular import parse_commit_message as angular_parser  # noqa isort:skip
 from .parser_tag import parse_commit_message as tag_parser  # noqa isort:skip
 


### PR DESCRIPTION
Fixing [build not passing due to isort failure](https://circleci.com/gh/relekang/python-semantic-release/379).
Fixing circleci badge so it points to the master branch.