### PR TITLE
ci(circleci): moved to 2.1 for simplification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,72 +1,47 @@
-version: 2
+version: 2.1
+
+executors:
+  py36:
+    docker:
+      - image: circleci/python:3.6
+
+commands:
+  setup:
+    steps:
+      - checkout
+      - run: sudo pip install tox
+      - restore_cache:
+          keys:
+            - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
+      - run: tox --notest
+      - save_cache:
+          key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
+          paths:
+            - .tox
 
 jobs:
   flake8:
-    docker:
-      - image: circleci/python:3.6
-
+    executor: py36
     steps:
-      - checkout
-      - run: sudo pip install tox
-      - restore_cache:
-         keys:
-           - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-      - run: tox --notest
-      - save_cache:
-         key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-         paths:
-           - .tox
+      - setup
       - run: tox -e flake8
 
   mypy:
-    docker:
-      - image: circleci/python:3.6
-
+    executor: py36
     steps:
-      - checkout
-      - run: sudo pip install tox
-      - restore_cache:
-         keys:
-           - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-      - run: tox --notest
-      - save_cache:
-         key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-         paths:
-           - .tox
+      - setup
       - run: tox -e mypy
 
   isort:
-    docker:
-      - image: circleci/python:3.6
-
+    executor: py36
     steps:
-      - checkout
-      - run: sudo pip install tox
-      - restore_cache:
-         keys:
-           - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-      - run: tox --notest
-      - save_cache:
-         key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-         paths:
-           - .tox
+      - setup
       - run: tox -e isort
 
   tests:
-    docker:
-      - image: circleci/python:3.6
-
+    executor: py36
     steps:
-      - checkout
-      - run: sudo pip install tox
-      - restore_cache:
-         keys:
-           - v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-      - run: tox --notest
-      - save_cache:
-         key: v1-tox-{{ checksum "tox.ini" }}-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/dev.txt" }}
-         paths:
-           - .tox
+      - setup
       - run: tox -e py3-tests
       - run: tox -e coverage
 


### PR DESCRIPTION
In the spirit of being [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), moved to version and using [reusable commands](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands) and [reusable executors](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors), as available in version 2.1. See [CircleCI's configuration reference](https://circleci.com/docs/2.0/configuration-reference/) for more info.

Could have used Yaml Special features such as like anchors (&), aliases (*) and map merging (<<), [as used in GitLabCI](https://docs.gitlab.com/ee/ci/yaml/README.html#special-yaml-features), but did this work before remembering it... so now it is done :)