### PR TITLE
Add new config sources

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,12 +3,18 @@
 Configuration
 -------------
 
-All configuration described here belongs in ``setup.cfg`` in a section:
-``semantic_release``.
+All configuration options described here can be overloaded in a ``setup.cfg`` file in a ``semantic_release`` section and/or in a ``pyproject.toml`` file in a ``[tool.semantic_release]`` section. ``pyproject.toml`` is loaded after ``setup.cfg`` and has the priority.
 
 ``version_variable``
     The filename and variable name of where the
     version number is stored, e.g. ``semantic_release/__init__.py:__version__``.
+
+``version_source``
+    The way we get and set the new version. Can be ``commit`` or ``tag``.
+    If set to ``tag``, will get the current version from the latest tag matching ``vX.Y.Z``.
+    This won't change the source defined in ``version_variable``.
+    If set to ``commit`` (default), will get the current version from the source defined
+    in ``version_variable``, edit the file and commit it.
 
 ``commit_parser``
     Import path to a python function that can parse commit messages and return

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,6 +5,10 @@ Configuration
 
 All configuration options described here can be overloaded in a ``setup.cfg`` file in a ``semantic_release`` section and/or in a ``pyproject.toml`` file in a ``[tool.semantic_release]`` section. ``pyproject.toml`` is loaded after ``setup.cfg`` and has the priority.
 
+Moreover, those configuration values can be overloaded with the ``-D`` option, like so ::
+
+    semantic-release <command> -D <option_name>=<option_value>
+
 ``version_variable``
     The filename and variable name of where the
     version number is stored, e.g. ``semantic_release/__init__.py:__version__``.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@ twine~=1.12
 requests~=2.21
 wheel
 ndebug~=0.1
+toml==0.10.0

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -14,7 +14,7 @@ from .history import (evaluate_version_bump, get_current_version, get_new_versio
 from .history.logs import generate_changelog, markdown_changelog
 from .hvcs import check_build_status, check_token, post_changelog
 from .pypi import upload_to_pypi
-from .settings import config
+from .settings import config, overload_configuration
 from .vcs_helpers import (checkout, commit_new_version, get_current_head_hash,
                           get_repository_owner_and_name, push_new_version, tag_new_version)
 
@@ -27,7 +27,10 @@ COMMON_OPTIONS = [
     click.option('--post', is_flag=True, help='Post changelog.'),
     click.option('--retry', is_flag=True, help='Retry the same release, do not bump.'),
     click.option('--noop', is_flag=True,
-                 help='No-operations mode, finds the new version number without changing it.')
+                 help='No-operations mode, finds the new version number without changing it.'),
+    click.option('--define', '-D', multiple=True,
+                 help='setting="value", override a configuration value'),
+    overload_configuration,
 ]
 
 

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -6,15 +6,33 @@ import os
 from os import getcwd
 from typing import Callable
 
+import ndebug
+import toml
+
 from .errors import ImproperConfigurationError
+
+debug = ndebug.create(__name__)
 
 
 def _config():
     parser = configparser.ConfigParser()
+    current_dir = getcwd()
     parser.read([
         os.path.join(os.path.dirname(__file__), 'defaults.cfg'),
-        os.path.join(getcwd(), 'setup.cfg')
+        os.path.join(current_dir, 'setup.cfg')
     ])
+    toml_conf_path = os.path.join(current_dir, 'pyproject.toml')
+    if os.path.isfile(toml_conf_path):
+        with open(toml_conf_path, 'r') as pyproject_toml:
+            try:
+                pyproject_toml = toml.load(pyproject_toml)
+                for key, value in (pyproject_toml.get('tool', {})
+                                                 .get('semantic_release', {})
+                                                 .items()):
+                    parser['semantic_release'][key] = str(value)
+            except toml.TomlDecodeError:
+                debug("Could not decode pyproject.toml")
+
     return parser
 
 

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -3,6 +3,7 @@
 import configparser
 import importlib
 import os
+from functools import wraps
 from os import getcwd
 from typing import Callable
 
@@ -51,3 +52,19 @@ def current_commit_parser() -> Callable:
         return getattr(importlib.import_module(module), parts[-1])
     except (ImportError, AttributeError) as error:
         raise ImproperConfigurationError('Unable to import parser "{}"'.format(error))
+
+
+def overload_configuration(func):
+    """This decorator gets the content of the "define" array and edits "config"
+    according to the pairs of key/value.
+    """
+    @wraps(func)
+    def wrap(*args, **kwargs):
+        if 'define' in kwargs:
+            for defined_param in kwargs['define']:
+                pair = defined_param.split('=', maxsplit=1)
+                if len(pair) == 2:
+                    config['semantic_release'][str(pair[0])] = str(pair[1])
+        return func(*args, **kwargs)
+
+    return wrap

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,18 @@
 import mock  # noqa
+import pytest
+
+import semantic_release
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    """This fixture will be used for every test here.
+    Since some tests here edit the configuration, we want to reload it.
+    We also need to reload the modules that use config.
+    """
+    yield
+    from importlib import reload
+    reload(semantic_release.settings)
+    reload(semantic_release.vcs_helpers)
+    reload(semantic_release.history)
+    reload(semantic_release.history.logs)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,7 +7,9 @@ from semantic_release.errors import ImproperConfigurationError
 from semantic_release.history import parser_angular
 from semantic_release.settings import _config, current_commit_parser
 
-from . import mock
+from . import mock, reset_config
+
+assert reset_config
 
 
 class ConfigTests(TestCase):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,7 @@
+import os
 from unittest import TestCase
+
+import toml
 
 from semantic_release.errors import ImproperConfigurationError
 from semantic_release.history import parser_angular
@@ -26,6 +29,52 @@ class ConfigTests(TestCase):
         self.assertFalse(config.getboolean('semantic_release', 'check_build_status'))
         self.assertEqual(config.get('semantic_release', 'hvcs'), 'github')
         self.assertEqual(config.getboolean('semantic_release', 'upload_to_pypi'), True)
+
+    @mock.patch('semantic_release.settings.getcwd', return_value='/tmp/')
+    def test_toml_override(self, mock_getcwd):
+        # create temporary toml config file
+        dummy_conf_path = '/tmp/pyproject.toml'
+        toml_conf_content = {
+            'tool': {
+                'foo': {'bar': 'baz'},
+                'semantic_release': {
+                    'upload_to_pypi': False,
+                    'version_source': 'tag',
+                    'foo': 'bar',
+                },
+            },
+        }
+        with open(dummy_conf_path, 'w') as dummy_conf_file:
+            toml.dump(toml_conf_content, dummy_conf_file)
+
+        config = _config()
+        mock_getcwd.assert_called_once_with()
+        self.assertEqual(config.get('semantic_release', 'hvcs'), 'github')
+        self.assertEqual(config.getboolean('semantic_release', 'upload_to_pypi'), False)
+        self.assertEqual(config.get('semantic_release', 'version_source'), 'tag')
+        self.assertEqual(config.get('semantic_release', 'foo'), 'bar')
+
+        # delete temporary toml config file
+        os.remove(dummy_conf_path)
+
+    @mock.patch('semantic_release.settings.debug')
+    @mock.patch('semantic_release.settings.getcwd', return_value='/tmp/')
+    def test_no_raise_toml_error(self, mock_getcwd, mock_debug):
+        # create temporary toml config file
+        dummy_conf_path = '/tmp/pyproject.toml'
+        bad_toml_conf_content = """
+        TITLE OF BAD TOML
+        [section]
+        key = # BAD BECAUSE NO VALUE
+        """
+        with open(dummy_conf_path, 'w') as dummy_conf_file:
+            dummy_conf_file.write(bad_toml_conf_content)
+
+        _ = _config()
+        mock_getcwd.assert_called_once_with()
+        mock_debug.assert_called_once_with('Could not decode pyproject.toml')
+        # delete temporary toml config file
+        os.remove(dummy_conf_path)
 
     @mock.patch('semantic_release.settings.config.get', lambda *x: 'nonexistent.parser')
     def test_current_commit_parser_should_raise_error_if_parser_module_do_not_exist(self):


### PR DESCRIPTION
This PR contains the load of configuration from two new sources :

* pyproject.toml (the new "standard" for python apps)
* command line using `-D`

Fixes #119 

Will be in conflict with #144 because of an added requirement (I will rebase on master when one is merged)