### PR TITLE
feat: allow users to get version from tag and write/commit bump to file

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -53,3 +53,7 @@ Moreover, those configuration values can be overloaded with the ``-D`` option, l
 ``hvcs``
     The name of your hvcs. Currently only ``github`` and ``gitlab`` are supported.
     Default: ``github``
+
+``commit_version_number``
+    Whether or not to commit changes when bumping version.
+    Default: True if ``version_source`` is `tag`, False if ``version_source`` is `commit`.

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -96,7 +96,9 @@ def version(**kwargs):
         return True
 
     set_new_version(new_version)
-    if config.get('semantic_release', 'version_source') == 'commit':
+    if config.get('semantic_release', 'commit_version_number', fallback=(
+                config.get('semantic_release', 'version_source') == 'commit')
+            ):
         commit_new_version(new_version)
     tag_new_version(new_version)
     click.echo('Bumping with a {0} version to {1}.'.format(level_bump, new_version))

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -47,8 +47,7 @@ def evaluate_version_bump(current_version: str, force: str = None) -> Optional[s
     commit_count = 0
 
     for _hash, commit_message in get_commit_log('v{0}'.format(current_version)):
-        if (commit_message.startswith(current_version) and
-                config.get('semantic_release', 'version_source') == 'commit'):
+        if commit_message.startswith(current_version):
             debug('"{}" is commit for {}. breaking loop'.format(commit_message, current_version))
             break
         try:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -59,11 +59,6 @@ class EvaluateVersionBumpTest(TestCase):
         self.assertEqual(evaluate_version_bump('0.0.0', 'minor'), 'minor')
         self.assertEqual(evaluate_version_bump('0.0.0', 'patch'), 'patch')
 
-    def test_should_account_for_commits_earlier_than_last_commit(self):
-        with mock.patch('semantic_release.history.logs.get_commit_log',
-                        lambda *a, **kw: MAJOR_LAST_RELEASE_MINOR_AFTER):
-            self.assertEqual(evaluate_version_bump('1.1.0'), 'minor')
-
     def test_should_not_skip_commits_mentioning_other_commits(self):
         with mock.patch('semantic_release.history.logs.get_commit_log',
                         lambda *a, **kw: MAJOR_MENTIONING_LAST_VERSION):


### PR DESCRIPTION
Before this commit, version was bumped in the file, but only committed
if version was obtained from `version_variable` (version_source == `commit`).
Also added a relevant test and a description for this new option.

Fixes #104