### PR TITLE
feat: make the vcs functionalities work with gitlab

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,3 +49,7 @@ Moreover, those configuration values can be overloaded with the ``-D`` option, l
 
 ``branch``
     The branch to run releases from. Default: master
+
+``hvcs``
+    The name of your hvcs. Currently only ``github`` and ``gitlab`` are supported.
+    Default: ``github``

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -14,7 +14,7 @@ Used to check if Circle CI environment. See :ref:`automatic-checks`
 
 DEBUG
 ^^^^^
-Set to ``*`` to get a lot of debug information. 
+Set to ``*`` to get a lot of debug information.
 See :ref:`debug-usage` for more.
 
 .. _env-frigg:
@@ -41,6 +41,18 @@ and click on *Personal access token*.
 GITLAB_CI
 ^^^^^^^^^
 Used to check if Gitlab CI environment. See :ref:`automatic-checks`
+Automatically defined in a gitlab ci environment.
+
+GL_TOKEN
+^^^^^^^^
+A personal access token from gitlab. This is used for authenticating
+when pushing tags, publishing releases etc...
+
+CI_SERVER_HOST
+^^^^^^^^^^^^^^
+Host component of the GitLab instance URL, without protocol and port.
+Example: gitlab.example.com
+Automatically set in a gitlab ci environment (from version 12.1).
 
 
 .. _env-pypi_password:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ requests~=2.21
 wheel
 ndebug~=0.1
 toml==0.10.0
+python-gitlab==1.10.0

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -1,8 +1,9 @@
 """HVCS
 """
 import os
-from typing import Optional, Tuple
+from typing import Optional
 
+import gitlab
 import ndebug
 import requests
 
@@ -11,9 +12,14 @@ from .settings import config
 
 debug = ndebug.create(__name__)
 debug_gh = ndebug.create(__name__ + ':github')
+debug_gl = ndebug.create(__name__ + ':gitlab')
 
 
 class Base(object):
+
+    @staticmethod
+    def domain() -> str:
+        raise NotImplementedError
 
     @staticmethod
     def token() -> Optional[str]:
@@ -25,14 +31,22 @@ class Base(object):
 
     @classmethod
     def post_release_changelog(
-            cls, owner: str, repo: str, version: str, changelog: str) -> Tuple[bool, dict]:
+            cls, owner: str, repo: str, version: str, changelog: str) -> bool:
         raise NotImplementedError
 
 
 class Github(Base):
     """Github helper class
     """
-    DOMAIN = 'https://api.github.com'
+    API_URL = 'https://api.github.com'
+
+    @staticmethod
+    def domain() -> str:
+        """Github domain property
+
+        :return: The Github domain
+        """
+        return 'github.com'
 
     @staticmethod
     def token() -> Optional[str]:
@@ -54,7 +68,7 @@ class Github(Base):
         """
         url = '{domain}/repos/{owner}/{repo}/commits/{ref}/status'
         response = requests.get(
-            url.format(domain=Github.DOMAIN, owner=owner, repo=repo, ref=ref)
+            url.format(domain=Github.API_URL, owner=owner, repo=repo, ref=ref)
         )
         if debug_gh.enabled:
             debug_gh('check_build_status: state={}'.format(response.json()['state']))
@@ -62,29 +76,29 @@ class Github(Base):
 
     @classmethod
     def post_release_changelog(
-            cls, owner: str, repo: str, version: str, changelog: str) -> Tuple[bool, dict]:
-        """Check build status
+            cls, owner: str, repo: str, version: str, changelog: str) -> bool:
+        """Post release changelog
 
         :param owner: The owner namespace of the repository
         :param repo: The repository name
         :param version: The version number
         :param changelog: The release notes for this version
 
-        :return: The status of the request and the response json
+        :return: The status of the request
         """
         url = '{domain}/repos/{owner}/{repo}/releases?access_token={token}'
         tag = 'v{0}'.format(version)
         debug_gh('listing releases')
         response = requests.post(
             url.format(
-                domain=Github.DOMAIN,
+                domain=Github.API_URL,
                 owner=owner,
                 repo=repo,
                 token=Github.token()
             ),
             json={'tag_name': tag, 'body': changelog, 'draft': False, 'prerelease': False}
         )
-        status, payload = response.status_code == 201, response.json()
+        status, _ = response.status_code == 201, response.json()
         debug_gh('response #1, status_code={}, status={}'.format(response.status_code, status))
 
         if not status:
@@ -92,7 +106,7 @@ class Github(Base):
             url = '{domain}/repos/{owner}/{repo}/releases/tags/{tag}?access_token={token}'
             response = requests.get(
                 url.format(
-                    domain=Github.DOMAIN,
+                    domain=Github.API_URL,
                     owner=owner,
                     repo=repo,
                     token=Github().token(),
@@ -105,7 +119,7 @@ class Github(Base):
             debug_gh('getting release_id', release_id)
             response = requests.post(
                 url.format(
-                    domain=Github.DOMAIN,
+                    domain=Github.API_URL,
                     owner=owner,
                     repo=repo,
                     token=Github().token(),
@@ -113,9 +127,87 @@ class Github(Base):
                 ),
                 json={'tag_name': tag, 'body': changelog, 'draft': False, 'prerelease': False}
             )
-            status, payload = response.status_code == 200, response.json()
+            status, _ = response.status_code == 200, response.json()
             debug_gh('response #3, status_code={}, status={}'.format(response.status_code, status))
-        return status, payload
+        return status
+
+
+class Gitlab(Base):
+    """Gitlab helper class
+    """
+    API_URL = 'https://' + os.environ.get('CI_SERVER_HOST', 'gitlab.com')
+
+    @staticmethod
+    def domain() -> str:
+        """Gitlab domain property
+
+        :return: The Gitlab instance domain
+        """
+        return os.environ.get('CI_SERVER_HOST', 'gitlab.com')
+
+    @staticmethod
+    def token() -> Optional[str]:
+        """Gitlab token property
+
+        :return: The Gitlab token environment variable (GL_TOKEN) value
+        """
+        return os.environ.get('GL_TOKEN')
+
+    @staticmethod
+    def check_build_status(owner: str, repo: str, ref: str) -> bool:
+        """Check last build status
+
+        :param owner: The owner namespace of the repository. It includes all groups and subgroups.
+        :param repo: The repository name
+        :param ref: The sha1 hash of the commit ref
+
+        :return: the status of the pipeline (False if a job failed)
+        """
+        gl = gitlab.Gitlab(Gitlab.API_URL, private_token=Gitlab.token())
+        gl.auth()
+        jobs = (gl.projects.get(owner+'/'+repo)
+                  .commits.get(ref)
+                  .statuses.list())
+        for job in jobs:
+            if job['status'] not in ['success', 'skipped']:
+                if job['status'] == 'pending':
+                    debug_gl('check_build_status: job {} is still in pending status'
+                             .format(job['name']))
+                    return False
+                elif job['status'] == 'failed' and not job['allow_failure']:
+                    debug_gl('check_build_status: job {} failed'
+                             .format(job['name']))
+                    return False
+        return True
+
+    @classmethod
+    def post_release_changelog(
+            cls, owner: str, repo: str, version: str, changelog: str) -> bool:
+        """Post release changelog
+
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param version: The version number
+        :param changelog: The release notes for this version
+
+        :return: The status of the request
+        """
+        ref = 'v' + version
+        gl = gitlab.Gitlab(Gitlab.API_URL, private_token=Gitlab.token())
+        gl.auth()
+        try:
+            tag = gl.projects.get(owner+'/'+repo).tags.get(ref)
+            tag.set_release_description(changelog)
+        except gitlab.exceptions.GitlabGetError:
+            debug_gl('Tag {} was not found for project {}'
+                     .format(ref, owner+'/'+repo))
+            return False
+        except gitlab.exceptions.GitlabUpdateError:
+            debug_gl('Failed to update tag {} for project {}'
+                     .format(ref, owner+'/'+repo))
+            return False
+
+        return True
 
 
 def get_hvcs() -> Base:
@@ -144,7 +236,7 @@ def check_build_status(owner: str, repository: str, ref: str) -> bool:
     return get_hvcs().check_build_status(owner, repository, ref)
 
 
-def post_changelog(owner: str, repository: str, version: str, changelog: str) -> Tuple[bool, dict]:
+def post_changelog(owner: str, repository: str, version: str, changelog: str) -> bool:
     """
     Posts the changelog to the current hvcs release API
 
@@ -156,6 +248,24 @@ def post_changelog(owner: str, repository: str, version: str, changelog: str) ->
     """
     debug('post_changelog(owner={}, repository={}, version={})'.format(owner, repository, version))
     return get_hvcs().post_release_changelog(owner, repository, version, changelog)
+
+
+def get_token() -> Optional[str]:
+    """
+    Returns the token for the current VCS
+
+    :return: The token in string form
+    """
+    return get_hvcs().token()
+
+
+def get_domain() -> Optional[str]:
+    """
+    Returns the domain for the current VCS
+
+    :return: The domain in string form
+    """
+    return get_hvcs().domain()
 
 
 def check_token() -> bool:

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -135,27 +135,34 @@ def tag_new_version(version: str):
 
 
 def push_new_version(
-    gh_token: str = None,
+    auth_token: str = None,
     owner: str = None,
     name: str = None,
-    branch: str = "master"
+    branch: str = 'master',
+    domain: str = 'github.com',
 ):
     """
     Runs git push and git push --tags.
 
-    :param gh_token: Github token used to push.
+    :param auth_token: Authentication token used to push.
     :param owner: Organisation or user that owns the repository.
     :param name: Name of repository.
     :param branch: Branch to push to
+    :param server_url: Name of the server. Will be used to identify a gitlab instance.
     :raises GitError: if GitCommandError is raised
     """
 
     check_repo()
     server = 'origin'
-    if gh_token:
-        server = 'https://{token}@{repo}'.format(
-            token=gh_token,
-            repo='github.com/{owner}/{name}.git'.format(owner=owner, name=name)
+    if auth_token:
+        token = auth_token
+        if config.get('semantic_release', 'hvcs') == 'gitlab':
+            token = 'gitlab-ci-token:' + token
+        server = 'https://{token}@{server_url}/{owner}/{name}.git'.format(
+            token=token,
+            server_url=domain,
+            owner=owner,
+            name=name,
         )
 
     try:
@@ -163,8 +170,8 @@ def push_new_version(
         repo.git.push('--tags', server, branch)
     except GitCommandError as error:
         message = str(error)
-        if gh_token:
-            message = message.replace(gh_token, '[GH_TOKEN]')
+        if auth_token:
+            message = message.replace(auth_token, '[AUTH_TOKEN]')
         raise GitError(message)
 
 

--- a/tests/mocks/mock_gitlab.py
+++ b/tests/mocks/mock_gitlab.py
@@ -1,0 +1,83 @@
+import gitlab
+
+from .. import mock
+
+gitlab.Gitlab('')  # instanciation necessary to discover gitlab ProjectManager
+
+
+class _GitlabProject:
+
+    def __init__(self, status):
+        self.commits = {'my_ref': self._Commit(status)}
+        self.tags = self._Tags()
+
+    class _Commit:
+
+        def __init__(self, status):
+            self.statuses = self._Statuses(status)
+
+        class _Statuses:
+
+            def __init__(self, status):
+                if status == 'pending':
+                    self.jobs = [
+                        {'name': 'good_job', 'status': 'passed', 'allow_failure': False},
+                        {'name': 'slow_job', 'status': 'pending', 'allow_failure': False},
+                    ]
+                elif status == 'failure':
+                    self.jobs = [
+                        {'name': 'good_job', 'status': 'passed', 'allow_failure': False},
+                        {'name': 'bad_job', 'status': 'failed', 'allow_failure': False},
+                    ]
+                elif status == 'allow_failure':
+                    self.jobs = [
+                        {'name': 'notsobad_job', 'status': 'failed', 'allow_failure': True},
+                        {'name': 'good_job2', 'status': 'passed', 'allow_failure': False},
+                    ]
+                elif status == 'success':
+                    self.jobs = [
+                        {'name': 'good_job1', 'status': 'passed', 'allow_failure': True},
+                        {'name': 'good_job2', 'status': 'passed', 'allow_failure': False},
+                    ]
+
+            def list(self):
+                return self.jobs
+
+    class _Tags:
+
+        def __init__(self):
+            pass
+
+        def get(self, version):
+            if version == 'vmy_good_tag':
+                return self._Tag()
+            elif version == 'vmy_locked_tag':
+                return self._Tag(locked=True)
+            else:
+                raise gitlab.exceptions.GitlabGetError
+
+        class _Tag:
+
+            def __init__(self, locked=False):
+                self.locked = locked
+
+            def set_release_description(self, changelog):
+                if self.locked:
+                    raise gitlab.exceptions.GitlabUpdateError
+
+
+GITLAB_MOCKS = [
+    mock.patch('os.environ', {'GL_TOKEN': 'token'}),
+    mock.patch('configparser.ConfigParser.get', return_value='gitlab'),
+    mock.patch('gitlab.Gitlab.auth'),
+]
+
+
+def mock_gitlab(status='success'):
+    def wraps(func):
+        for option in reversed(GITLAB_MOCKS):
+            func = option(func)
+        mock_project = mock.patch('gitlab.v4.objects.ProjectManager',
+                                  return_value={'owner/repo': _GitlabProject(status)})
+        return mock_project(func)
+    return wraps

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -67,13 +67,14 @@ def test_get_current_head_hash(mocker):
     assert get_current_head_hash() == 'commit-hash'
 
 
-def test_push_should_not_print_gh_token(mock_git):
+def test_push_should_not_print_auth_token(mock_git):
     mock_git.configure_mock(**{
-        'push.side_effect': GitCommandError('gh--token', 1, b'gh--token', b'gh--token')
+        'push.side_effect': GitCommandError('auth--token', 1, b'auth--token', b'auth--token')
     })
+    mock.patch('semantic_release.settings.config.ConfigParser.get', 'gitlab')
     with pytest.raises(GitError) as excinfo:
-        push_new_version(gh_token='gh--token')
-    assert 'gh--token' not in str(excinfo)
+        push_new_version(auth_token='auth--token')
+    assert 'auth--token' not in str(excinfo)
 
 
 def test_checkout_should_checkout_correct_branch(mock_git):


### PR DESCRIPTION
Adds python-gitlab as requirement.
Refactored github specific methods while keeping default behavior.
Also removed an unused return value for post_release_changelog.
Also refactored the secret filtering method.
Updated the related tests.

Fixes #121

Will be in conflict with #142 because of an added requirement (I will rebase on master when one is merged)