### PR TITLE
fix: update list of commit types to include build, ci and perf

### DIFF
--- a/docs/commit-log-parsing.rst
+++ b/docs/commit-log-parsing.rst
@@ -30,7 +30,7 @@ the changelog. The format of the output should be as follows::
     (level to bump, type of change, scope of change, (subject, body, footer))
 
 The type of change can be one of `feature`, `fix` or any string in lowercase.
-The `feature` will result in an minor release and `fix` indicates an patch release.
+The `feature` will result in an minor release and `fix` or `perf` indicates a patch release.
 To create a major release the body in the last item in the tuple must contain::
 
     BREAKING CHANGE: <explanation>

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -17,7 +17,13 @@ LEVELS = {
     3: 'major',
 }
 
-CHANGELOG_SECTIONS = ['feature', 'fix', 'breaking', 'documentation']
+CHANGELOG_SECTIONS = [
+    'feature',
+    'fix',
+    'breaking',
+    'documentation',
+    'performance',
+]
 
 re_breaking = re.compile('BREAKING CHANGE: (.*)')
 
@@ -73,8 +79,14 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
     :return: a dict with different changelog sections
     """
     debug('generate_changelog("{}", "{}")'.format(from_version, to_version))
-    changes: dict = {'feature': [], 'fix': [],
-                     'documentation': [], 'refactor': [], 'breaking': []}
+    changes: dict = {
+        'feature': [],
+        'fix': [],
+        'documentation': [],
+        'refactor': [],
+        'breaking': [],
+        'performance': [],
+    }
 
     found_the_release = to_version is None
 

--- a/semantic_release/history/parser_angular.py
+++ b/semantic_release/history/parser_angular.py
@@ -17,6 +17,9 @@ TYPES = {
     'docs': 'documentation',
     'style': 'style',
     'refactor': 'refactor',
+    'build': 'build',
+    'ci': 'ci',
+    'perf': 'performance',
     'chore': 'chore',
 }
 
@@ -27,6 +30,15 @@ re_parser = re.compile(
     r'(:?\n\n(?P<text>.+))?',
     re.DOTALL
 )
+
+MINOR_TYPES = [
+    'feat',
+]
+
+PATCH_TYPES = [
+    'fix',
+    'perf',
+]
 
 
 def parse_commit_message(message: str) -> Tuple[int, str, str, Tuple[str, str, str]]:
@@ -47,10 +59,10 @@ def parse_commit_message(message: str) -> Tuple[int, str, str, Tuple[str, str, s
     if parsed.group('text') and 'BREAKING CHANGE' in parsed.group('text'):
         level_bump = 3
 
-    if parsed.group('type') == 'feat':
+    if parsed.group('type') in MINOR_TYPES:
         level_bump = max([level_bump, 2])
 
-    if parsed.group('type') == 'fix':
+    if parsed.group('type') in PATCH_TYPES:
         level_bump = max([level_bump, 1])
 
     body, footer = parse_text_block(parsed.group('text'))

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -187,7 +187,8 @@ class MarkdownChangelogTests(TestCase):
             'breaking': [('21', 'Uses super-feature as default instead of dull-feature.')],
             'feature': [('145', 'Add non-breaking super-feature'), ('134', 'Add super-feature')],
             'fix': [('234', 'Fix bug in super-feature')],
-            'documentation': [('0', 'Document super-feature')]
+            'documentation': [('0', 'Document super-feature')],
+            'performance': [],
         })
         self.assertEqual(
             markdown,
@@ -210,7 +211,14 @@ class MarkdownChangelogTests(TestCase):
         self.assertEqual(
             markdown_changelog(
                 '1.0.1',
-                {'refactor': [], 'breaking': [], 'feature': [], 'fix': [], 'documentation': []},
+                {
+                    'refactor': [],
+                    'breaking': [],
+                    'feature': [],
+                    'fix': [],
+                    'documentation': [],
+                    'performance': [],
+                },
             ),
             ''
         )
@@ -220,7 +228,14 @@ class MarkdownChangelogTests(TestCase):
             '## v1.0.1\n',
             markdown_changelog(
                 '1.0.1',
-                {'refactor': [], 'breaking': [], 'feature': [], 'fix': [], 'documentation': []},
+                {
+                    'refactor': [],
+                    'breaking': [],
+                    'feature': [],
+                    'fix': [],
+                    'documentation': [],
+                    'performance': [],
+                },
                 header=True
             )
         )
@@ -230,6 +245,13 @@ class MarkdownChangelogTests(TestCase):
             'v1.0.1',
             markdown_changelog(
                 '1.0.1',
-                {'refactor': [], 'breaking': [], 'feature': [], 'fix': [], 'documentation': []},
+                {
+                    'refactor': [],
+                    'breaking': [],
+                    'feature': [],
+                    'fix': [],
+                    'documentation': [],
+                    'performance': [],
+                },
             )
         )


### PR DESCRIPTION
Also added perf to the types that trigger a patch update

Fixes #145