### PR TITLE
fix: support repo urls without git terminator

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -85,7 +85,7 @@ def get_repository_owner_and_name() -> Tuple[str, str]:
 
     check_repo()
     url = repo.remote('origin').url
-    parts = re.search(r'[:/]([^\.:]+)/([^/]+).git$', url)
+    parts = re.search(r'[:/]([^\.:]+)/([^/.]+)(.git)?$', url)
     if not parts:
         raise HvcsRepoParseError
     debug('get_repository_owner_and_name', parts)

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -60,8 +60,10 @@ def test_push_new_version_with_custom_branch(mock_git):
     ("git@github.com:group/project.git", ("group", "project")),
     ("git@gitlab.example.com:group/project.git", ("group", "project")),
     ("git@gitlab.example.com:group/subgroup/project.git", ("group/subgroup", "project")),
+    ("git@gitlab.example.com:group/subgroup/project", ("group/subgroup", "project")),
     ("https://github.com/group/project.git", ("group", "project")),
     ("https://gitlab.example.com/group/subgroup/project.git", ("group/subgroup", "project")),
+    ("https://gitlab.example.com/group/subgroup/project", ("group/subgroup", "project")),
     ("bad_repo_url", HvcsRepoParseError),
 ])
 def test_get_repository_owner_and_name(mocker, origin_url, expected_result):


### PR DESCRIPTION
Addresses https://github.com/relekang/python-semantic-release/issues/109#issuecomment-531053386