### PR TITLE
fix: update regex to get repository owner and name for project with dots

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -85,7 +85,7 @@ def get_repository_owner_and_name() -> Tuple[str, str]:
 
     check_repo()
     url = repo.remote('origin').url
-    parts = re.search(r'[:/]([^\.:]+)/([^/.]+)(.git)?$', url)
+    parts = re.search(r'[:/]([^\.:]+)/([^/]*?)(.git)?$', url)
     if not parts:
         raise HvcsRepoParseError
     debug('get_repository_owner_and_name', parts)

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -64,6 +64,8 @@ def test_push_new_version_with_custom_branch(mock_git):
     ("https://github.com/group/project.git", ("group", "project")),
     ("https://gitlab.example.com/group/subgroup/project.git", ("group/subgroup", "project")),
     ("https://gitlab.example.com/group/subgroup/project", ("group/subgroup", "project")),
+    ("https://gitlab.example.com/group/subgroup/pro.ject", ("group/subgroup", "pro.ject")),
+    ("https://gitlab.example.com/group/subgroup/pro.ject.git", ("group/subgroup", "pro.ject")),
     ("bad_repo_url", HvcsRepoParseError),
 ])
 def test_get_repository_owner_and_name(mocker, origin_url, expected_result):


### PR DESCRIPTION
Remove the dot from the second capture group to allow project names
containing dots to be matched.
Instead of a greedy '+' operator, use '*?' to allow the second group to
give back the '.git' (to avoid including it in the project name)

Fixes #151 