### PR TITLE
Implement exclamation points for breaking changes

### DIFF
--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -110,15 +110,22 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
 
             changes[message[1]].append((_hash, message[3][0]))
 
-            if message[3][1] and 'BREAKING CHANGE' in message[3][1]:
-                parts = re_breaking.match(message[3][1])
-                if parts:
-                    changes['breaking'].append((_hash, parts.group(1)))
+            # Handle breaking change message
+            parts = None
+            if message[0] == 3:
+                # parse footer (standard)
+                if message[3][2] and 'BREAKING CHANGE' in message[3][2]:
+                    parts = re_breaking.match(message[3][2])
+                # parse body (not standard, kept for backwards compatibility)
+                elif message[3][1] and 'BREAKING CHANGE' in message[3][1]:
+                    parts = re_breaking.match(message[3][1])
 
-            if message[3][2] and 'BREAKING CHANGE' in message[3][2]:
-                parts = re_breaking.match(message[3][2])
                 if parts:
-                    changes['breaking'].append((_hash, parts.group(1)))
+                    breaking_description = parts.group(1)
+                else:
+                    breaking_description = message[3][0]
+
+                changes['breaking'].append((_hash, breaking_description))
 
         except UnknownCommitMessageStyleError as err:
             debug('Ignoring', err)

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -1,6 +1,5 @@
 """Logs
 """
-import re
 from typing import Optional
 
 import ndebug
@@ -8,6 +7,7 @@ import ndebug
 from ..errors import UnknownCommitMessageStyleError
 from ..settings import config, current_commit_parser
 from ..vcs_helpers import get_commit_log
+from .parser_helpers import re_breaking
 
 debug = ndebug.create(__name__)
 
@@ -24,8 +24,6 @@ CHANGELOG_SECTIONS = [
     'documentation',
     'performance',
 ]
-
-re_breaking = re.compile('BREAKING CHANGE: (.*)')
 
 
 def evaluate_version_bump(current_version: str, force: str = None) -> Optional[str]:

--- a/semantic_release/history/parser_angular.py
+++ b/semantic_release/history/parser_angular.py
@@ -25,7 +25,8 @@ TYPES = {
 
 re_parser = re.compile(
     r'(?P<type>' + '|'.join(TYPES.keys()) + ')'
-    r'(?:\((?P<scope>[^\n]+)\))?: '
+    r'(?:\((?P<scope>[^\n]+)\))?'
+    r'(?P<break>!)?: '
     r'(?P<subject>[^\n]+)'
     r'(:?\n\n(?P<text>.+))?',
     re.DOTALL
@@ -56,7 +57,7 @@ def parse_commit_message(message: str) -> Tuple[int, str, str, Tuple[str, str, s
         )
 
     level_bump = 0
-    if parsed.group('text') and 'BREAKING CHANGE' in parsed.group('text'):
+    if parsed.group('break') or (parsed.group('text') and 'BREAKING CHANGE' in parsed.group('text')):
         level_bump = 3
 
     if parsed.group('type') in MINOR_TYPES:

--- a/semantic_release/history/parser_helpers.py
+++ b/semantic_release/history/parser_helpers.py
@@ -1,6 +1,9 @@
 """Commit parser helpers
 """
+import re
 from typing import Tuple
+
+re_breaking = re.compile('BREAKING[ -]CHANGE: (.*)')
 
 
 def parse_text_block(text: str) -> Tuple[str, str]:

--- a/tests/parsers/test_angular.py
+++ b/tests/parsers/test_angular.py
@@ -20,6 +20,10 @@ def test_parser_return_correct_bump_level():
         3
     )
     assert(
+        angular_parser('feat(parsers)!: Add new parser pattern\n\nBREAKING CHANGE:')[0] ==
+        3
+    )
+    assert(
         angular_parser('feat(parsers): Add new parser pattern\n\n'
                        'New pattern is awesome\n\nBREAKING CHANGE:')[0] ==
         3
@@ -28,6 +32,8 @@ def test_parser_return_correct_bump_level():
     assert angular_parser('fix(parser): Fix regex in angular parser')[0] == 1
     assert angular_parser(
         'test(parser): Add a test for angular parser')[0] == 0
+    assert angular_parser('feat(parser)!: Edit dat parsing stuff')[0] == 3
+    assert angular_parser('fix!: Edit dat parsing stuff again')[0] == 3
 
 
 def test_parser_return_type_from_commit_message():

--- a/tests/parsers/test_angular.py
+++ b/tests/parsers/test_angular.py
@@ -16,16 +16,20 @@ def test_parser_raises_unknown_message_style():
 
 def test_parser_return_correct_bump_level():
     assert(
-        angular_parser('feat(parsers): Add new parser pattern\n\nBREAKING CHANGE:')[0] ==
+        angular_parser('feat(parsers): Add new parser pattern\n\nBREAKING CHANGE: ')[0] ==
         3
     )
     assert(
-        angular_parser('feat(parsers)!: Add new parser pattern\n\nBREAKING CHANGE:')[0] ==
+        angular_parser('feat(parsers)!: Add new parser pattern\n\nBREAKING CHANGE: ')[0] ==
         3
     )
     assert(
         angular_parser('feat(parsers): Add new parser pattern\n\n'
-                       'New pattern is awesome\n\nBREAKING CHANGE:')[0] ==
+                       'New pattern is awesome\n\nBREAKING CHANGE: ')[0] ==
+        3
+    )
+    assert(
+        angular_parser('feat(parsers): Add new parser pattern\n\nBREAKING-CHANGE: change !')[0] ==
         3
     )
     assert angular_parser('feat(parser): Add emoji parser')[0] == 2

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -19,9 +19,18 @@ MAJOR2 = (
     'BREAKING CHANGE: Uses super-feature as default instead of dull-feature.'
 )
 MAJOR_MENTIONING_1_0_0 = (
-    '222',
+    '223',
     'feat(x): Add super-feature\n\nSome explanation\n\n'
     'BREAKING CHANGE: Uses super-feature as default instead of dull-feature from v1.0.0.'
+)
+MAJOR_EXCL_WITH_FOOTER = (
+    '231',
+    'feat(x)!: Add another feature\n\n'
+    'BREAKING CHANGE: Another feature, another breaking change'
+)
+MAJOR_EXCL_NOT_FOOTER = (
+    '232',
+    'fix!: Fix a big bug that everyone exploited\n\nThis is the reason you should not exploit bugs'
 )
 MINOR = ('111', 'feat(x): Add non-breaking super-feature')
 PATCH = ('24', 'fix(x): Fix bug in super-feature')
@@ -136,6 +145,24 @@ class GenerateChangelogTests(TestCase):
                         lambda *a, **kw: PATCH_COMMIT_MESSAGES + [('23', 'chore(x): change x')]):
             changelog = generate_changelog('0.0.0')
             self.assertNotIn('chore', changelog)
+
+    def test_should_get_right_breaking_description(self):
+        param_list = [
+            (MAJOR, 'Uses super-feature as default instead of dull-feature.'),
+            (MAJOR2, 'Uses super-feature as default instead of dull-feature.'),
+            (
+                MAJOR_MENTIONING_1_0_0,
+                'Uses super-feature as default instead of dull-feature from v1.0.0.'
+            ),
+            (MAJOR_EXCL_WITH_FOOTER, 'Another feature, another breaking change'),
+            (MAJOR_EXCL_NOT_FOOTER, 'Fix a big bug that everyone exploited'),
+        ]
+        for commit, expected_description in param_list:
+            with mock.patch('semantic_release.history.logs.get_commit_log',
+                            lambda *a, **kw: [commit]):
+                with self.subTest(hash=commit[0]):
+                    changelog = generate_changelog('0.0.0')
+                    self.assertEqual(changelog['breaking'][0][1], expected_description)
 
 
 def test_current_version_should_return_correct_version():


### PR DESCRIPTION
This PR is mostly for #156 but I also added a change for point 16 of the specification : https://www.conventionalcommits.org/en/v1.0.0/

* Implement the use of exclamation points to describe breaking changes
* Allow the use of `BREAKING-CHANGE` as synonym of `BREAKING CHANGE`

I can put the second commit in another branch/PR if you prefer.

Fixes #156 