### PR TITLE
Refactor GitHub API calls into separate functions

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -150,7 +150,7 @@ class Github(Base):
         )
         release_id = response.json()['id']
         debug_gh('response #2, status_code={}, release_id={}'
-            .format(response.status_code, release_id))
+                 .format(response.status_code, release_id))
 
         return release_id
 

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -92,7 +92,7 @@ class Github(Base):
 
         if not success:
             debug_gh('unsuccessful, looking for an existing release to update', tag)
-            release_id = Github.get_tag(owner, repo, tag)
+            release_id = Github.get_release_by_tag(owner, repo, tag)
 
             debug_gh('updating release', release_id)
             success = Github.edit_release(owner, repo, release_id, tag, changelog)
@@ -127,7 +127,7 @@ class Github(Base):
         return response.status_code == 201
 
     @classmethod
-    def get_tag(cls, owner, repo, tag):
+    def get_release_by_tag(cls, owner, repo, tag):
         """Get a release by tag name
 
         https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name


### PR DESCRIPTION
The following changes have been made to the `Github` class in `hvcs.py`:

- Separate each type of request into its own function
    - Function docstrings include links to the GitHub API documentation
- Rename the variable `status` to `success`, as the word "status" may imply that it contains the numerical status code of the request
- Make debug logging more easily understandable

This should not affect the actual behaviour of the code.