### PR TITLE
Capitalize changelog messages

### DIFF
--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -106,12 +106,7 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             if message[1] not in changes:
                 continue
 
-            changes[message[1]].append((
-                _hash,
-                # Capitalize the first letter of the message
-                message[3][0].capitalize()
-
-            ))
+            changes[message[1]].append((_hash, message[3][0].capitalize()))
 
             # Handle breaking change message
             parts = None

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -109,7 +109,8 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             changes[message[1]].append((
                 _hash,
                 # Capitalize the first letter of the message
-                message[3][0][0].upper() + message[3][0][1:]
+                message[3][0].capitalize()
+
             ))
 
             # Handle breaking change message

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -106,7 +106,11 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             if message[1] not in changes:
                 continue
 
-            changes[message[1]].append((_hash, message[3][0]))
+            changes[message[1]].append((
+                _hash,
+                # Capitalize the first letter of the message
+                message[3][0][0].upper() + message[3][0][1:]
+            ))
 
             # Handle breaking change message
             parts = None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -164,6 +164,12 @@ class GenerateChangelogTests(TestCase):
                     changelog = generate_changelog('0.0.0')
                     self.assertEqual(changelog['breaking'][0][1], expected_description)
 
+    def test_messages_are_capitalized(self):
+        with mock.patch('semantic_release.history.logs.get_commit_log',
+                        lambda *a, **k: [('23', 'fix(x): abcd')]):
+            changelog = generate_changelog('0.0.0')
+            self.assertEqual(changelog['fix'][0][1], 'Abcd')
+
 
 def test_current_version_should_return_correct_version():
     assert get_current_version() == semantic_release.__version__


### PR DESCRIPTION
Capitalize the first letter of commit messages in the changelog, regardless of whether they are capitalized in the commit itself. This helps to make the change notes look neater where some commits have capital letters and others do not, such as [this release](https://github.com/relekang/python-semantic-release/releases/tag/v4.5.1).