### PR TITLE
Use application/octet-stream for .whl asset uploads

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -15,8 +15,8 @@ debug = ndebug.create(__name__)
 debug_gh = ndebug.create(__name__ + ':github')
 debug_gl = ndebug.create(__name__ + ':gitlab')
 
-# Add a mime type for wheels so asset upload doesn't fail
-mimetypes.add_type('application/x-wheel+zip', '.whl', False)
+# Add a mime type for wheels
+mimetypes.add_type('application/octet-stream', '.whl')
 
 
 class Base(object):


### PR DESCRIPTION
Update the MIME type used for uploading wheels to GitHub releases to `application/octet-stream`.

- `application/octet-stream` is more generic, but it is better than using a non-official MIME type.
- I noticed that the non-standard type was sometimes causing internal server errors on the GitHub API when trying to upload `.whl` files.