### PR TITLE
fix: repair parsing of remotes in the gitlab ci format

### DIFF
--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -92,7 +92,7 @@ def get_repository_owner_and_name() -> Tuple[str, str]:
     check_repo()
     url = repo.remote('origin').url
     split_url = urlsplit(url)
-    path = split_url.netloc + split_url.path
+    path = split_url.path
     parts = re.search(r'[:/]([^:]+)/([^/]*?)(.git)?$', path)
     if not parts:
         raise HvcsRepoParseError

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -74,6 +74,18 @@ def test_push_new_version_with_custom_branch(mock_git):
         "https://gitlab.example.com/firstname.lastname/project.git",
         ("firstname.lastname", "project")
     ),
+    (
+        "https://gitlab-ci-token:MySuperToken@gitlab.example.com/group/project.git",
+        ("group", "project")
+    ),
+    (
+        "https://gitlab-ci-token:MySuperToken@gitlab.example.com/group/subgroup/project.git",
+        ("group/subgroup", "project")
+    ),
+    (
+        "https://gitlab-ci-token:MySuperToken@gitlab.example.com/group/sub.group/project.git",
+        ("group/sub.group", "project")
+    ),
     ("bad_repo_url", HvcsRepoParseError),
 ])
 def test_get_repository_owner_and_name(mocker, origin_url, expected_result):


### PR DESCRIPTION
Format is:
"https://gitlab-ci-token:MySuperToken@gitlab.example.com/group/project.git"

Problem was due to the regex modification for #179

Fixes #181