### PR TITLE
Set up releasing with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,5 @@ jobs:
       uses: AlphaMycelium/psr-action@v0.2.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pypi_username: relekang
+        pypi_username: ${{ secrets.PYPI_USERNAME }}
         pypi_password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Python Semantic Release
+      uses: AlphaMycelium/psr-action@v0.2.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pypi_username: relekang
+        pypi_password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This was listed as one of the tasks on #109:
> Setup github actions for releasing this project by calling on the current source code.

I have set up a workflow to run on pushes to the `master` branch. For this to work, **the `PYPI_PASSWORD` secret must be set [here](https://github.com/relekang/python-semantic-release/settings/secrets/) by @relekang before merging.**