### PR TITLE
Make AUTHORS.rst dynamic

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,7 @@
 Contributors
 ------------
 
-* Rolf Erik Lekang (@relekang)
-* Jannis Leidel (@jezdez)
+|contributors|
+
+.. |contributors| image:: https://contributors-img.web.app/image?repo=relekang/python-semantic-release
+   :target: https://github.com/relekang/python-semantic-release/graphs/contributors


### PR DESCRIPTION
Change AUTHORS.rst to have an automatically-updated grid of all users who have contributed to the repository, sorted by number of commits. The image also serves as a link to the [contributor graph](https://github.com/relekang/python-semantic-release/graphs/contributors).

Made with [contributors-img](https://contributors-img.web.app).