### PR TITLE
Move GitHub Action into this repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.repository == 'relekang/python-semantic-release'
 
     steps:
     - uses: actions/checkout@v1
 
     - name: Python Semantic Release
-      uses: AlphaMycelium/psr-action@v0.2.1
+      uses: ./
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         pypi_username: ${{ secrets.PYPI_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# This Dockerfile is only for GitHub Actions
+
+FROM python:3.7
+
+COPY . /python-semantic-release
+RUN python -m pip install /python-semantic-release
+
+COPY action.sh /action.sh
+ENTRYPOINT ["/action.sh"]

--- a/action.rst
+++ b/action.rst
@@ -1,0 +1,91 @@
+GitHub Action for Python Semantic Release
+=========================================
+
+Inputs
+------
+
++-------------------+-------------------------------------------------+
+| Input             | Description                                     |
++===================+=================================================+
+| ``github_token``  | **Required.** The GitHub token used to push     |
+|                   | release notes and new commits/tags created by   |
+|                   | the tool. Usually                               |
+|                   | ``${{ secrets.GITHUB_TOKEN }}``.                |
++-------------------+-------------------------------------------------+
+| ``pypi_username`` | **Required unless upload_to_pypi is false in    |
+|                   | setup.cfg.** Username with project access to    |
+|                   | push to PyPi.                                   |
++-------------------+-------------------------------------------------+
+| ``pypi_password`` | **Required unless upload_to_pypi is false in    |
+|                   | setup.cfg.** Password to the account specified  |
+|                   | in ``pypi_username``.                           |
++-------------------+-------------------------------------------------+
+| ``directory``     | A sub-directory to ``cd`` into before running.  |
+|                   | Defaults to the root of the repository.         |
++-------------------+-------------------------------------------------+
+
+Further options are **required** to be configured in either
+``setup.cfg`` or ``pyproject.toml`` as documented `here`_.
+
+Example Workflow
+----------------
+
+.. code:: yaml
+
+   name: Semantic Release
+
+   on:
+     push:
+       branches:
+         - master
+
+   jobs:
+     release:
+       runs-on: ubuntu-latest
+
+       steps:
+       - uses: actions/checkout@v1
+
+       - name: Python Semantic Release
+         uses: relekang/python-semantic-release@v4
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           pypi_username: <ADD YOUR USERNAME HERE>
+           pypi_password: ${{ secrets.PYPI_PASSWORD }}
+
+``PYPI_PASSWORD`` should be set as a secret on your repository's
+settings page. It is safe to include your username directly in the
+configuration, although you could also set it as a secret if you wish.
+The ``GITHUB_TOKEN`` secret is automatically configured by Actions.
+
+Multiple Projects
+~~~~~~~~~~~~~~~~~
+
+If you have multiple projects stored within a single repository (or your
+project is not at the root of the repository), you can pass the
+``directory`` input. The step can be called multiple times to release
+multiple projects.
+
+.. code:: yaml
+
+   - name: Release Project 1
+     uses: relekang/python-semantic-release@v4
+     with:
+       directory: ./project1
+       github_token: ${{ secrets.GITHUB_TOKEN }}
+       pypi_username: <ADD YOUR USERNAME HERE>
+       pypi_password: ${{ secrets.PYPI_PASSWORD }}
+
+   - name: Release Project 2
+     uses: relekang/python-semantic-release@v4
+     with:
+       directory: ./project2
+       github_token: ${{ secrets.GITHUB_TOKEN }}
+       pypi_username: <ADD YOUR USERNAME HERE>
+       pypi_password: ${{ secrets.PYPI_PASSWORD }}
+
+Note that the release notes posted to GitHub will not currently
+distinguish which project they are from (see `this issue`_).
+
+.. _here: https://python-semantic-release.readthedocs.io/en/latest/configuration.html
+.. _this issue: https://github.com/relekang/python-semantic-release/issues/168

--- a/action.sh
+++ b/action.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+
+# Copy inputs into correctly-named environment variables
+export GH_TOKEN="${INPUT_GITHUB_TOKEN}"
+export PYPI_USERNAME="${INPUT_PYPI_USERNAME}"
+export PYPI_PASSWORD="${INPUT_PYPI_PASSWORD}"
+
+# Change to configured directory
+cd "${INPUT_DIRECTORY}"
+
+# Set Git details
+git config --global user.name "github-actions"
+git config --global user.email "action@github.com"
+
+# Run Semantic Release
+DEBUG="*" semantic-release publish -D commit_author="github-actions <action@github.com>"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,19 @@
+name: 'Python Semantic Release'
+
+description: 'Automatic semantic versioning for python projects'
+
+inputs:
+  directory:
+    description: 'Sub-directory to cd into before running semantic-release'
+    default: '.'
+  github_token:
+    description: 'GitHub token used to push release notes and new commits/tags'
+    required: true
+  pypi_username:
+    description: 'Username with project access to push to PyPi'
+  pypi_password:
+    description: 'Password to the account specified in pypi_username'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
Move [psr-action](https://github.com/AlphaMycelium/psr-action) into this repository. Fixes #196.

Documentation for the action is in `action.rst`. We may wish to add a link to this somewhere in the docs, and possibly move the file. I chose to place the action metadata directly into the root of the repository as `Dockerfile` needs to be there anyway as there is currently no other way to change the build context.

This also means that it is possible to publish the action on the GitHub Marketplace if we want to do so in the future, although this is not at all necessary for it to function (some changes to `readme.rst` would be required before publishing).