### PR TITLE
Fix capitalization in changelog

### DIFF
--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -129,7 +129,10 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             if message[1] not in changes:
                 continue
 
-            changes[message[1]].append((_hash, message[3][0].capitalize()))
+            # Capialize the first letter of the message, leaving others as they were
+            # (using str.capitalize() would make the other letters lowercase)
+            capital_message = message[3][0][0].upper() + message[3][0][1:]
+            changes[message[1]].append((_hash, capital_message))
 
             # Handle breaking change message
             parts = None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -173,9 +173,9 @@ class GenerateChangelogTests(TestCase):
 
     def test_messages_are_capitalized(self):
         with mock.patch('semantic_release.history.logs.get_commit_log',
-                        lambda *a, **k: [('23', 'fix(x): abcd')]):
+                        lambda *a, **k: [('23', 'fix(x): abCD')]):
             changelog = generate_changelog('0.0.0')
-            self.assertEqual(changelog['fix'][0][1], 'Abcd')
+            self.assertEqual(changelog['fix'][0][1], 'AbCD')
 
 
 def test_current_version_should_return_correct_version():


### PR DESCRIPTION
Use of `capitalize()` capitalized the first letter of commit messages as expected, but all subsequent letters became lowercase. I have fixed this so that the other letters are not changed, and updated the testing to check for this.

This bug is quite evident in [the v4.11.0 release notes](https://github.com/relekang/python-semantic-release/releases/tag/v4.11.0) where the text 'GitHub Action' has no capital letters.