### PR TITLE
Use a named tuple for parsed commits

### DIFF
--- a/semantic_release/history/parser_angular.py
+++ b/semantic_release/history/parser_angular.py
@@ -9,7 +9,7 @@ from typing import Tuple
 import ndebug
 
 from ..errors import UnknownCommitMessageStyleError
-from .parser_helpers import parse_text_block, re_breaking
+from .parser_helpers import ParsedCommit, parse_text_block, re_breaking
 
 debug = ndebug.create(__name__)
 
@@ -82,7 +82,7 @@ def parse_commit_message(message: str) -> Tuple[int, str, str, Tuple[str, str, s
             parsed.group('scope'),
             (parsed.group('subject'), body, footer)
         ))
-    return (
+    return ParsedCommit(
         level_bump,
         TYPES[parsed.group('type')],
         parsed.group('scope'),

--- a/semantic_release/history/parser_helpers.py
+++ b/semantic_release/history/parser_helpers.py
@@ -1,9 +1,20 @@
 """Commit parser helpers
 """
+import collections
 import re
 from typing import Tuple
 
 re_breaking = re.compile('BREAKING[ -]CHANGE: (.*)')
+
+
+ParsedCommit = collections.namedtuple(
+    'ParsedCommit', [
+        'bump',
+        'type',
+        'scope',
+        'descriptions'
+    ]
+)
 
 
 def parse_text_block(text: str) -> Tuple[str, str]:

--- a/semantic_release/history/parser_tag.py
+++ b/semantic_release/history/parser_tag.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 
 from ..errors import UnknownCommitMessageStyleError
 from ..settings import config
-from .parser_helpers import parse_text_block
+from .parser_helpers import ParsedCommit, parse_text_block
 
 re_parser = re.compile(
     r'(?P<subject>[^\n]+)'
@@ -58,4 +58,5 @@ def parse_commit_message(message: str) -> Tuple[int, str, Optional[str], Tuple[s
         level_bump = 3
 
     body, footer = parse_text_block(parsed.group('text'))
-    return level_bump, level, None, (subject.strip(), body.strip(), footer.strip())
+    descriptions = (subject.strip(), body.strip(), footer.strip())
+    return ParsedCommit(level_bump, level, None, descriptions)


### PR DESCRIPTION
This improves readability as we can use attributes such as `bump` and `descriptions` instead of confusing numeric indices.