### PR TITLE
Run release daily instead of on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Semantic Release
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    # Release changes once a day
+    - cron: '0 0 * * *'
 
 jobs:
   release:


### PR DESCRIPTION
This gives a chance to merge multiple pull requests or create multiple commits without each one triggering an individual release.

For example, v5.0.1 and v5.0.2 were created on the same day with only one commit in each of them. Running daily would have created a single release with both commits.