### PR TITLE
Version tag as default release name in Github

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -114,7 +114,7 @@ class Github(Base):
         """
         response = requests.post(
             f'{Github.API_URL}/repos/{owner}/{repo}/releases',
-            json={'tag_name': tag, 'body': changelog, 'draft': False, 'prerelease': False},
+            json={'tag_name': tag, 'name': tag, 'body': changelog, 'draft': False, 'prerelease': False},
             headers={'Authorization': 'token {}'.format(Github.token())}
         )
         debug_gh('Release creation: status={}'.format(response.status_code))


### PR DESCRIPTION
## Description
This PR could be a good solution to the problem described in #210 .

## Implementation
In this PR I added a new parameter in the section code where a HTTP request is made to the [Github API for releases](https://developer.github.com/v3/repos/releases/#create-a-release) specifically the section where a release is created. I included the release name and set it to the tag version by default.