### PR TITLE
doc: updated doc with new ParsedCommit object instead of nested Tuple

### DIFF
--- a/docs/commit-log-parsing.rst
+++ b/docs/commit-log-parsing.rst
@@ -25,9 +25,10 @@ If you think this is all well and cool, but the angular style is not for you.
 No need to worry because custom parsers are supported. A parser is basically
 a python function that takes the commit message as the only argument and
 returns a tuple with the information needed to evaluate the commit and build
-the changelog. The format of the output should be as follows::
+the changelog. The format of the output should be a `ParsedCommit` object with
+the following parameters::
 
-    (level to bump, type of change, scope of change, (subject, body, footer))
+    ParsedCommit(level to bump, type of change, scope of change, (subject, body, footer))
 
 The type of change can be one of `feature`, `fix` or any string in lowercase.
 The `feature` will result in an minor release and `fix` or `perf` indicates a patch release.


### PR DESCRIPTION
I just bumped (no pun intended) into a `'tuple' object has no attribute 'bump'` error. 

This is due to a change in the last major release:
```
$ git diff v4.11.0 upstream/master -- semantic_release/history/parser_angular.py
-    return (
+    return ParsedCommit(
         level_bump,
         TYPES[parsed.group('type')],
         parsed.group('scope'),
```

Now it accepts an instance of `ParsedCommit` instead of a nested `Tuple`. I updated the doc to reflect this.