### PR TITLE
Close stale questions automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,13 +12,13 @@ jobs:
     - uses: actions/stale@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 4
-        days-before-close: 3
+        days-before-stale: 10
+        days-before-close: 4
         only-labels: 'question'
         stale-issue-message: >-
           This question has been marked as stale because there has been
-          no further activity in the last 4 days. If the issue remains
-          stale for the next 3 days (a total of one week with no activity),
+          no further activity in the last 10 days. If the issue remains
+          stale for the next 4 days (a total of two weeks with no activity),
           then it will be assumed that the question has been resolved and
           the issue will be automatically closed.
         stale-issue-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Stale Questions
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 4
+        days-before-close: 3
+        only-labels: 'question'
+        stale-issue-message: >-
+          This question has been marked as stale because there has been
+          no further activity in the last 4 days. If the issue remains
+          stale for the next 3 days (a total of one week with no activity),
+          then it will be assumed that the question has been resolved and
+          the issue will be automatically closed.
+        stale-issue-label: 'stale'


### PR DESCRIPTION
Any issues which are labelled as a question will be marked as `stale` after 4 days with no activity, and then closed after a further 3 days. This doesn't affect other types of issues.