### PR TITLE
Check all paragraphs for breaking changes

### DIFF
--- a/semantic_release/history/parser_helpers.py
+++ b/semantic_release/history/parser_helpers.py
@@ -2,7 +2,7 @@
 """
 import collections
 import re
-from typing import Tuple
+from typing import List
 
 re_breaking = re.compile("BREAKING[ -]CHANGE: (.*)")
 
@@ -12,19 +12,16 @@ ParsedCommit = collections.namedtuple(
 )
 
 
-def parse_text_block(text: str) -> Tuple[str, str]:
+def parse_paragraphs(text: str) -> List[str]:
     """
-    This will take a text block and return a tuple with body and footer,
-    where footer is defined as the last paragraph.
+    This will take a text block and return a tuple containing each
+    paragraph with single line breaks collapsed into spaces.
 
     :param text: The text string to be divided.
-    :return: A tuple with body and footer,
-    where footer is defined as the last paragraph.
+    :return: A tuple of paragraphs.
     """
-    body, footer = "", ""
-    if text:
-        body = text.split("\n\n")[0]
-        if len(text.split("\n\n")) == 2:
-            footer = text.split("\n\n")[1]
-
-    return body.replace("\n", " "), footer.replace("\n", " ")
+    return [
+        paragraph.replace("\n", " ")
+        for paragraph in text.split("\n\n")
+        if len(paragraph) > 0
+    ]

--- a/semantic_release/history/parser_tag.py
+++ b/semantic_release/history/parser_tag.py
@@ -1,12 +1,12 @@
 """Legacy commit parser from Python Semantic Release 1.0"""
 import logging
 import re
-from typing import Optional, Tuple
+from typing import Optional
 
 from ..errors import UnknownCommitMessageStyleError
 from ..helpers import LoggedFunction
 from ..settings import config
-from .parser_helpers import ParsedCommit, parse_text_block
+from .parser_helpers import ParsedCommit, parse_paragraphs
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ re_parser = re.compile(r"(?P<subject>[^\n]+)" r"(:?\n\n(?P<text>.+))?", re.DOTAL
 @LoggedFunction(logger)
 def parse_commit_message(
     message: str,
-) -> Tuple[int, str, Optional[str], Tuple[str, str, str]]:
+) -> ParsedCommit:
     """
     Parse a commit message according to the 1.0 version of python-semantic-release.
 
@@ -60,6 +60,10 @@ def parse_commit_message(
         level = "breaking"
         level_bump = 3
 
-    body, footer = parse_text_block(parsed.group("text"))
-    descriptions = (subject.strip(), body.strip(), footer.strip())
+    if parsed.group("text"):
+        descriptions = parse_paragraphs(parsed.group("text"))
+    else:
+        descriptions = list()
+    descriptions.insert(0, subject.strip())
+    
     return ParsedCommit(level_bump, level, None, descriptions)

--- a/tests/parsers/test_helpers.py
+++ b/tests/parsers/test_helpers.py
@@ -1,33 +1,18 @@
-from semantic_release.history.parser_helpers import parse_text_block
+from semantic_release.history.parser_helpers import parse_paragraphs
 
 
-def test_parse_text_block_with_no_content():
-    body, parse = parse_text_block("")
-
-    assert body == ""
-    assert parse == ""
+def test_parse_paragraphs_with_no_content():
+    paragraphs = parse_paragraphs("")
+    assert len(paragraphs) == 0
 
 
-def test_parse_text_block_with_only_body():
-    body, parse = parse_text_block("This is a body paragraph.")
-
-    assert body == "This is a body paragraph."
-    assert parse == ""
-
-
-def test_parse_text_block_with_body_and_footer():
-    body, parse = parse_text_block(
-        "This is a body paragraph.\n\n...and this is a footer"
-    )
-
-    assert body == "This is a body paragraph."
-    assert parse == "...and this is a footer"
+def test_parse_paragraphs():
+    paragraphs = parse_paragraphs("Paragraph 0\n\nParagraph 1")
+    assert len(paragraphs) == 2
+    assert paragraphs[0] == "Paragraph 0"
+    assert paragraphs[1] == "Paragraph 1"
 
 
-def test_parse_text_block_with_multiline_body_and_multiline_footer():
-    body, parse = parse_text_block(
-        "This is a body\nparagraph.\n\n...and this is\na footer"
-    )
-
-    assert body == "This is a body paragraph."
-    assert parse == "...and this is a footer"
+def test_parse_paragraphs_multiline():
+    paragraphs = parse_paragraphs("This paragraph is over\nmultiple lines.")
+    assert paragraphs[0] == "This paragraph is over multiple lines."

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -30,6 +30,13 @@ MAJOR_MENTIONING_1_0_0 = (
     "feat(x): Add super-feature\n\nSome explanation\n\n"
     "BREAKING CHANGE: Uses super-feature as default instead of dull-feature from v1.0.0.",
 )
+MAJOR_MULTIPLE_FOOTERS = (
+    "244",
+    "feat(x): Lots of breaking changes\n\n"
+    "BREAKING CHANGE: Breaking change 1\n\n"
+    "Not a BREAKING CHANGE\n\n"
+    "BREAKING CHANGE: Breaking change 2"
+)
 MAJOR_EXCL_WITH_FOOTER = (
     "231",
     "feat(x)!: Add another feature\n\n"
@@ -213,6 +220,16 @@ class GenerateChangelogTests(TestCase):
                 with self.subTest(hash=commit[0]):
                     changelog = generate_changelog("0.0.0")
                     self.assertEqual(changelog["breaking"][0][1], expected_description)
+
+    def test_should_get_multiple_breaking_descriptions(self):
+        with mock.patch(
+            "semantic_release.history.logs.get_commit_log",
+            lambda *a, **kw: [MAJOR_MULTIPLE_FOOTERS],
+        ):
+            changelog = generate_changelog("0.0.0")
+            assert len(changelog["breaking"]) == 2
+            assert changelog["breaking"][0][1] == "Breaking change 1"
+            assert changelog["breaking"][1][1] == "Breaking change 2"
 
     def test_messages_are_capitalized(self):
         with mock.patch(


### PR DESCRIPTION
Check each paragraph of the commit's description for breaking changes, instead of only a body and footer.

- Breaking changes will always be detected when squashing commits
- Multiple breaking changes can be found in one commit

Fixes #200