### PR TITLE
Add link to view commit range in changelog

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -136,6 +136,17 @@ The available options are:
 
 Default: `feature, fix, breaking, documentation, performance`
 
+.. _config-compare_link:
+
+``compare_link``
+----------------
+When set to true, add a link to view the commit range since the previous
+release, on GitHub. Only appears when using :ref:`cmd-publish`.
+
+.. note::
+  If you are using a different HVCS, the link will not be included
+  regardless of this option.
+
 Distributions
 =============
 

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -248,7 +248,10 @@ def publish(**kwargs):
                     owner,
                     name,
                     new_version,
-                    markdown_changelog(new_version, log, header=False),
+                    markdown_changelog(
+                        new_version, log, header=False,
+                        previous_version=current_version
+                    ),
                 )
             except GitError:
                 logger.error("Posting changelog failed")

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -15,3 +15,4 @@ remove_dist=true
 build_command=python setup.py sdist bdist_wheel
 branch=master
 changelog_sections=feature,fix,breaking,documentation,performance
+compare_link=false

--- a/tests/history/test_markdown_changelog.py
+++ b/tests/history/test_markdown_changelog.py
@@ -1,4 +1,17 @@
-from semantic_release.history.logs import markdown_changelog
+import mock
+
+from semantic_release.history.logs import markdown_changelog, get_github_compare_url
+
+
+def test_github_compare_url():
+    with mock.patch(
+        'semantic_release.history.logs.get_repository_owner_and_name',
+        return_value=['owner', 'name']
+    ):
+        assert (
+            get_github_compare_url('1.0.0', '2.0.0') ==
+            "https://github.com/owner/name/compare/v1.0.0...v2.0.0"
+        )
 
 
 def test_should_output_all_sections():
@@ -77,4 +90,32 @@ def test_should_output_heading():
             "performance": [],
         },
         header=True,
+    )
+
+
+def test_compare_url(mocker):
+    mocker.patch(
+        'semantic_release.history.logs.config.getboolean',
+        return_value=True
+    )
+    mocker.patch(
+        'semantic_release.history.logs.get_repository_owner_and_name',
+        return_value=['owner', 'name']
+    )
+
+    assert (
+        "**[See all commits in this version]"
+        "(https://github.com/owner/name/compare/v1.0.0...v2.0.0)**\n"
+        in markdown_changelog(
+            "2.0.0",
+            {
+                "refactor": [],
+                "breaking": [],
+                "feature": [],
+                "fix": [],
+                "documentation": [],
+                "performance": [],
+            },
+            previous_version="1.0.0",
+        )
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,7 +514,10 @@ def test_publish_giterror_when_posting(mocker):
     )
     mock_check_token.assert_called_once_with()
     mock_generate.assert_called_once_with("current", "new")
-    mock_markdown.assert_called_once_with("new", "super changelog", header=False)
+    mock_markdown.assert_called_once_with(
+        "new", "super changelog",
+        header=False, previous_version='current'
+    )
     mock_post.assert_called_once_with("owner", "name", "new", "super md changelog")
 
 


### PR DESCRIPTION
Display a link in the changelog to the page comparing commits between this release and the previous one.

This is configured using the config option `compare_link`, and is off by default since GitHub displays a "compare" menu next to the release for the same purpose:

![image](https://user-images.githubusercontent.com/28959268/81408516-48450b00-9135-11ea-9c45-82a0cbe5224a.png)

Fixes #218