### PR TITLE
Capture logging output in tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_main_should_call_correct_function(mocker, runner):
     assert result.exit_code == 0
 
 
-def test_version_by_commit_should_call_correct_functions(mocker, runner):
+def test_version_by_commit_should_call_correct_functions(mocker):
     mocker.patch("semantic_release.cli.config.getboolean", lambda *x: False)
     mock_tag_new_version = mocker.patch("semantic_release.cli.tag_new_version")
     mock_commit_new_version = mocker.patch("semantic_release.cli.commit_new_version")
@@ -39,17 +39,17 @@ def test_version_by_commit_should_call_correct_functions(mocker, runner):
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
 
-    result = runner.invoke(main, ["version"])
+    version()
+
     mock_current_version.assert_called_once_with()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major")
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_commit_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
-    assert result.exit_code == 0
 
 
-def test_version_by_tag_should_call_correct_functions(mocker, runner):
+def test_version_by_tag_should_call_correct_functions(mocker):
     orig = semantic_release.cli.config.get
 
     def wrapped_config_get(*args, **kwargs):
@@ -81,18 +81,19 @@ def test_version_by_tag_should_call_correct_functions(mocker, runner):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
-    result = runner.invoke(main, ["version"])
+
+    version()
+
     mock_current_version.assert_called_once_with()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major")
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_commit_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
-    assert result.exit_code == 0
 
 
 def test_version_by_tag_with_commit_version_number_should_call_correct_functions(
-    mocker, runner
+    mocker
 ):
     orig = semantic_release.cli.config.get
 
@@ -118,13 +119,14 @@ def test_version_by_tag_with_commit_version_number_should_call_correct_functions
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
-    result = runner.invoke(main, ["version"])
+
+    version()
+
     mock_current_version.assert_called_once_with()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major")
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
-    assert result.exit_code == 0
 
 
 def test_force_major(mocker, runner):
@@ -166,16 +168,17 @@ def test_retry(mocker, runner):
     assert result.exit_code == 0
 
 
-def test_noop_mode(mocker, runner):
+def test_noop_mode(mocker):
     mock_tag_new_version = mocker.patch("semantic_release.cli.tag_new_version")
     mock_set_new = mocker.patch("semantic_release.cli.commit_new_version")
     mock_commit_new = mocker.patch("semantic_release.cli.set_new_version")
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "major")
-    result = runner.invoke(main, ["version", "--noop"])
+
+    version(noop=True)
+
     assert not mock_set_new.called
     assert not mock_commit_new.called
     assert not mock_tag_new_version.called
-    assert result.exit_code == 0
 
 
 def test_version_no_change(mocker, runner):
@@ -191,17 +194,18 @@ def test_version_no_change(mocker, runner):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
-    result = runner.invoke(main, ["version"])
+
+    version()
+
     mock_current_version.assert_called_once_with()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", None)
     assert not mock_set_new_version.called
     assert not mock_commit_new_version.called
     assert not mock_tag_new_version.called
-    assert result.exit_code == 0
 
 
-def test_version_check_build_status_fails(mocker, runner):
+def test_version_check_build_status_fails(mocker):
     mock_check_build_status = mocker.patch(
         "semantic_release.cli.check_build_status", return_value=False
     )
@@ -210,15 +214,16 @@ def test_version_check_build_status_fails(mocker, runner):
     mock_set_new = mocker.patch("semantic_release.cli.set_new_version")
     mocker.patch("semantic_release.cli.config.getboolean", lambda *x: True)
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "major")
-    result = runner.invoke(main, ["version"])
+
+    version()
+
     assert mock_check_build_status.called
     assert not mock_set_new.called
     assert not mock_commit_new.called
     assert not mock_tag_new_version.called
-    assert result.exit_code == 0
 
 
-def test_version_by_commit_check_build_status_succeeds(mocker, runner):
+def test_version_by_commit_check_build_status_succeeds(mocker):
     mocker.patch("semantic_release.cli.config.getboolean", lambda *x: True)
     mock_check_build_status = mocker.patch(
         "semantic_release.cli.check_build_status", return_value=True
@@ -227,15 +232,16 @@ def test_version_by_commit_check_build_status_succeeds(mocker, runner):
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "major")
     mock_commit_new = mocker.patch("semantic_release.cli.commit_new_version")
     mock_set_new = mocker.patch("semantic_release.cli.set_new_version")
-    result = runner.invoke(main, ["version"])
+
+    version()
+
     assert mock_check_build_status.called
     assert mock_set_new.called
     assert mock_commit_new.called
     assert mock_tag_new_version.called
-    assert result.exit_code == 0
 
 
-def test_version_by_tag_check_build_status_succeeds(mocker, runner):
+def test_version_by_tag_check_build_status_succeeds(mocker):
     orig = semantic_release.cli.config.get
 
     def wrapped_config_get(*args, **kwargs):
@@ -255,21 +261,24 @@ def test_version_by_tag_check_build_status_succeeds(mocker, runner):
     mock_set_new_version = mocker.patch("semantic_release.cli.set_new_version")
     mock_tag_new_version = mocker.patch("semantic_release.cli.tag_new_version")
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "major")
-    result = runner.invoke(main, ["version"])
+
+    version()
+
     assert mock_check_build_status.called
     assert mock_set_new_version.called
     assert mock_tag_new_version.called
-    assert result.exit_code == 0
 
 
-def test_version_check_build_status_not_called_if_disabled(mocker, runner):
+def test_version_check_build_status_not_called_if_disabled(mocker):
     mock_check_build_status = mocker.patch("semantic_release.cli.check_build_status")
     mocker.patch("semantic_release.cli.config.getboolean", lambda *x: False)
-    mocker.patch("semantic_release.cli.tag_new_version", None)
+    mocker.patch("semantic_release.cli.tag_new_version")
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "major")
-    mocker.patch("semantic_release.cli.commit_new_version", None)
-    mocker.patch("semantic_release.cli.set_new_version", None)
-    runner.invoke(main, ["version"])
+    mocker.patch("semantic_release.cli.commit_new_version")
+    mocker.patch("semantic_release.cli.set_new_version")
+
+    version()
+
     assert not mock_check_build_status.called
 
 
@@ -303,24 +312,26 @@ def test_version_retry(mocker):
     mock_get_new.assert_called_once_with("current", "patch")
 
 
-def test_publish_should_not_upload_to_pypi_if_option_is_false(mocker, runner):
+def test_publish_should_not_upload_to_pypi_if_option_is_false(mocker):
     mocker.patch("semantic_release.cli.checkout")
     mocker.patch("semantic_release.cli.ci_checks.check")
     mock_upload_pypi = mocker.patch("semantic_release.cli.upload_to_pypi")
     mock_upload_release = mocker.patch("semantic_release.cli.upload_to_release")
     mocker.patch("semantic_release.cli.post_changelog", lambda *x: True)
-    mocker.patch("semantic_release.cli.push_new_version", lambda *x: True)
+    mocker.patch("semantic_release.cli.push_new_version", return_value=True)
     mocker.patch("semantic_release.cli.version", lambda: True)
     mocker.patch("semantic_release.cli.markdown_changelog", lambda *x, **y: "CHANGES")
     mocker.patch("semantic_release.cli.get_new_version", lambda *x: "2.0.0")
     mocker.patch("semantic_release.cli.check_token", lambda: True)
     mocker.patch("semantic_release.cli.config.getboolean", lambda *x: False)
-    runner.invoke(main, ["publish"])
+
+    publish()
+
     assert not mock_upload_pypi.called
     assert not mock_upload_release.called
 
 
-def test_publish_should_do_nothing_when_version_fails(mocker, runner):
+def test_publish_should_do_nothing_when_version_fails(mocker):
     mocker.patch("semantic_release.cli.checkout")
     mocker.patch("semantic_release.cli.get_new_version", lambda *x: "2.0.0")
     mocker.patch("semantic_release.cli.evaluate_version_bump", lambda *x: "feature")
@@ -331,19 +342,18 @@ def test_publish_should_do_nothing_when_version_fails(mocker, runner):
     mock_push = mocker.patch("semantic_release.cli.push_new_version")
     mock_ci_check = mocker.patch("semantic_release.ci_checks.check")
     mock_version = mocker.patch("semantic_release.cli.version", return_value=False)
-    result = runner.invoke(main, ["publish"])
-    mock_version.assert_called_once_with(
-        noop=False, post=False, force_level=None, retry=False, define=(),
-    )
+
+    publish()
+
+    assert mock_version.called
     assert not mock_push.called
     assert not mock_upload_pypi.called
     assert not mock_upload_release.called
     assert not mock_log.called
     assert mock_ci_check.called
-    assert result.exit_code == 0
 
 
-def test_publish_should_call_functions(mocker, runner):
+def test_publish_should_call_functions(mocker):
     mock_push = mocker.patch("semantic_release.cli.push_new_version")
     mock_checkout = mocker.patch("semantic_release.cli.checkout")
     mock_version = mocker.patch("semantic_release.cli.version", return_value=True)
@@ -363,19 +373,15 @@ def test_publish_should_call_functions(mocker, runner):
     mocker.patch("semantic_release.cli.get_new_version", lambda *x: "2.0.0")
     mocker.patch("semantic_release.cli.check_token", lambda: True)
 
-    result = runner.invoke(main, ["publish"])
-    print(result.output)  # Print output for debugging should the test fail
+    publish()
 
-    assert result.exit_code == 0
     assert mock_ci_check.called
     assert mock_push.called
     assert mock_remove_dists.called
     assert mock_build_dists.called
     assert mock_pypi.called
     assert mock_release.called
-    mock_version.assert_called_once_with(
-        noop=False, post=False, force_level=None, retry=False, define=(),
-    )
+    assert mock_version.called
     mock_log.assert_called_once_with(
         u"relekang", "python-semantic-release", "2.0.0", "CHANGES"
     )


### PR DESCRIPTION
Adapt the CLI tests so that pytest can capture the log output, and display it if there is a failure. This helps with debugging.