### PR TITLE
docs: give example of multiple build commands

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -317,7 +317,8 @@ Default: `true`
 ``build_command``
 -----------------
 Command to build dists. Build output should be stored in the directory configured in
-``dist_path``.
+``dist_path``.  If necessary, multiple commands can be specified using ``&&``, e.g.
+``pip install -m flit && flit build``.
 
 Default: ``python setup.py sdist bdist_wheel``
 


### PR DESCRIPTION
I had a little trouble figuring out how to use a non-setup.py build command, so I thought it would be helpful to update the docs with an example of how to do this.