### PR TITLE
Correct docs for changelog command to reflect correct output stream

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -7,7 +7,7 @@ Commands
 
 changelog
 ^^^^^^^^^
-When executed this command will print the changelog to stdout.
+When executed this command will print the changelog to stderr.
 
 If the option ``--post`` is used then the program will check if
 there is a authentication token configured for your vcs provider


### PR DESCRIPTION
This resolves #250. In case it is the case that in general the following command prints to stderr, this now is reflected in the docs:

```shell
semantic-release --unreleased changelog
```

In case this is conditional, I am very happy to properly document the feature. Just give me a sign and I will dive deeper into the actual behaviour.