### PR TITLE
Send changelog to stdout

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -161,7 +161,8 @@ def changelog(*, unreleased=False, noop=False, post=False, **kwargs):
         log = generate_changelog(current_version, None)
     else:
         log = generate_changelog(previous_version, current_version)
-    logger.info(markdown_changelog(current_version, log, header=False))
+    # print is used to keep the changelog on stdout, separate from log messages
+    print(markdown_changelog(current_version, log, header=False))
 
     # Post changelog to HVCS if enabled
     if not noop and post:


### PR DESCRIPTION
This appears to have changed in 15b1f650f29761e1ab2a91b767cbff79b2057a4c, since [`click-log` uses stderr by default](https://github.com/click-contrib/click-log/blob/0d72a212ae7a45ab890d6e88a690679f8b946937/click_log/core.py#L46-L55).

Fixes #250, this PR is an alternative to #252.