### PR TITLE
fix: make statement uppercase in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 # This Dockerfile is only for GitHub Actions
 FROM python:3.7
 
-env PYTHONPATH /semantic-release
+ENV PYTHONPATH /semantic-release
 
 COPY . /semantic-release
 
 RUN cd /semantic-release && pip install .
 
 RUN python -m semantic_release.cli --help
-
 
 ENTRYPOINT ["/semantic-release/action.sh"]


### PR DESCRIPTION
I noticed that the `Dockerfile` with a lowercase statement for `env`. While it seems to work, this is not really following the usual casing convention.