### PR TITLE
Check commit logs with commitlint in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,3 +45,12 @@ jobs:
         run: python -m pip install mypy
       - name: mypy
         run: python -m mypy --ignore-missing-imports semantic_release
+
+  commitlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2


### PR DESCRIPTION
The contributing guide says that the project should itself follow the Angular commit convention, but there is nothing to enforce it AFAIK.

I had a similar problem on a project where I'm using `python-semantic-release` and I've added a Github action to test it on CI, you might find it useful too.

I also recently added [a pre-commit hook](https://github.com/alessandrojcm/commitlint-pre-commit-hook) to get even earlier feedback, let me know if you're interested.