### PR TITLE
Add `required` to all inputs in action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,15 +6,19 @@ inputs:
   directory:
     description: 'Sub-directory to cd into before running semantic-release'
     default: '.'
+    required: false
   github_token:
     description: 'GitHub token used to push release notes and new commits/tags'
     required: true
   pypi_token:
     description: 'PyPI API token'
+    required: false
   pypi_username:
     description: 'Username with project access to push to PyPI'
+    required: false
   pypi_password:
     description: 'Password to the account specified in pypi_username'
+    required: false
 
 runs:
   using: 'docker'


### PR DESCRIPTION
According to [the documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_idrequired), `inputs.<input_id>.required` is a required field, adding it as false to all inputs where it's missing.