### PR TITLE
feat(logs): include scope in changelogs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -297,6 +297,13 @@ will be updated.
 
 Default: ``<!--next-version-placeholder-->``.
 
+``changelog_scope``
+-------------------------
+If set to false, `**scope:**` (when scope is set for a commit) will not be
+prepended to the description when generating the changelog.
+
+Default: ``True``.
+
 ``changelog_capitalize``
 -------------------------
 If set to false commit messages will not be automatically capitalized when generating the changelog.

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -123,6 +123,13 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             if config.get("changelog_capitalize") is False:
                 formatted_message = message.descriptions[0]
 
+            # By default, feat(x): description shows up in changelog with the
+            # scope bolded, like:
+            #
+            # * **x**: description
+            if config.get("changelog_scope", True) and message.scope:
+                formatted_message = f'**{message.scope}:** {formatted_message}'
+
             changes[message.type].append((_hash, formatted_message))
 
             if message.breaking_descriptions:

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -36,6 +36,7 @@ def _config_from_ini(paths):
     parser.read(paths)
 
     flags = {
+        "changelog_scope",
         "check_build_status",
         "commit_version_number",
         "remove_dist",


### PR DESCRIPTION
When the scope is set, include it in changelogs, e.g.,
`"feat(x): some description"` becomes:
`* **x**: some description`

in the changelog. This is similar to how the Node semantic release (and conventional-changelog-generator) generate changelogs. If scope is not given, it's omitted.

Add a new config parameter changelog_scope to disable this behavior when set to `False`