### PR TITLE
refactor(history): move changelog_scope default

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -297,6 +297,8 @@ will be updated.
 
 Default: ``<!--next-version-placeholder-->``.
 
+.. _config-changelog_scope:
+
 ``changelog_scope``
 -------------------------
 If set to false, `**scope:**` (when scope is set for a commit) will not be

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -21,3 +21,4 @@ changelog_components=semantic_release.changelog.changelog_headers
 changelog_sections=feature,fix,breaking,documentation,performance,:boom:,:sparkles:,:children_crossing:,:lipstick:,:iphone:,:egg:,:chart_with_upwards_trend:,:ambulance:,:lock:,:bug:,:zap:,:goal_net:,:alien:,:wheelchair:,:speech_balloon:,:mag:,:apple:,:penguin:,:checkered_flag:,:robot:,:green_apple:,Other
 changelog_file=CHANGELOG.md
 changelog_placeholder=<!--next-version-placeholder-->
+changelog_scope=true

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -127,7 +127,7 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
             # scope bolded, like:
             #
             # * **x**: description
-            if config.get("changelog_scope", True) and message.scope:
+            if config.get("changelog_scope") and message.scope:
                 formatted_message = f"**{message.scope}:** {formatted_message}"
 
             changes[message.type].append((_hash, formatted_message))


### PR DESCRIPTION
Some cleanup from #281

- Move the default for changelog_scope from inline to defaults.cfg
- Add missing `.. _config-changelog_scope:` header in docs