### PR TITLE
fix(cli): skip remove_dist where not needed

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -298,7 +298,7 @@ def publish(**kwargs):
             logger.info("Uploading to HVCS release")
             upload_to_release(owner, name, new_version, dist_path)
         # Remove distribution files as they are no longer needed
-        if remove_dist:
+        if (upload_pypi or upload_release) and remove_dist:
             remove_dists(dist_path)
 
         logger.info("New release published")


### PR DESCRIPTION
Skip removing dist files when `upload_pypi` or `upload_release` are not set.

This way, people don't have to explicitly set `remove_dist()` to `False` when `build_dist()` has not run.

I _think_ this should be the correct behavior, and this seemed like a relatively simple way to accomplish it.

Open to suggestions on a) other / better ways to accomplish this and b) best / simplest ways to add a unit test for this.

Alternately, I could move the `if upload_pypi` and `if upload_release` conditionals inside that outer block:
https://github.com/relekang/python-semantic-release/blob/1b386c6d78772fd09351697c83fd4e39dfae1821/semantic_release/cli.py#L265
and then publish the changelog, however, I'm not sure whether that would be the wrong order of operations