### PR TITLE
fix(version_variable): fixing version extraction/setting from/in toml files via version_variable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,6 +49,11 @@ specify multiple versions:
         'docs/conf.py:version',
     ]
 
+When you specify a toml file with a version you must set the *toml-key-path* to
+the version string after the colon like so::
+
+    pyproject.toml:tool.poetry.version
+
 .. _config-version_pattern:
 
 ``version_pattern``

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "requests>=2.21,<3",
         "wheel",
         "toml~=0.10.0",
+        "tomlkit>=0.7,<1.0",
         "python-gitlab>=1.10,<2",
     ],
     extras_require={


### PR DESCRIPTION
I made a quick fix for #275 to correctly handle toml files like `pyproject.toml` holding version strings.

I personally would rewrite the whole `history/__init__.py` module as it is intended to work with regex only and my solution therefore is a bit clunky implemented.

I would exchange `toml` with `tomlkit` for the whole project also, as `tomlkit` is superior like I outlined [here](https://github.com/relekang/python-semantic-release/issues/275#issuecomment-743980593). But this is stuff for another issue/PR. 

### ATTENTION

**As of now** I do **not** plan to finish this PR, as I only quickly fixed the issue so I can test the tool to see if it meets my needs. Therefore I did not add any tests, but the current ones succeed altogether.

If someone wants to build on top of my changes you may hit me up by tagging me in the comments. I will be glad to add you as a collaborator to my fork so you can finish what I began.

Fixes #275 