### PR TITLE
fix(changelog): use "issues" link vs "pull"

### DIFF
--- a/semantic_release/changelog/changelog.py
+++ b/semantic_release/changelog/changelog.py
@@ -18,7 +18,7 @@ def add_pr_link(owner: str, repo_name: str, message: str) -> str:
         url = (
             f"https://gitlab.com/{owner}/{repo_name}/-/merge_requests/{pr_number}"
             if config.get("hvcs") == "gitlab"
-            else f"https://github.com/{owner}/{repo_name}/pull/{pr_number}"
+            else f"https://github.com/{owner}/{repo_name}/issues/{pr_number}"
         )
 
         return re.sub(pr_pattern, f" ([#{pr_number}]({url}))", message)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -38,7 +38,7 @@ def test_markdown_changelog():
         "* Add super-feature ([`134`](https://github.com/owner/repo_name/commit/134))\n"
         "\n"
         "### Fix\n"
-        "* Fix bug in super-feature ([#15](https://github.com/owner/repo_name/pull/15))"
+        "* Fix bug in super-feature ([#15](https://github.com/owner/repo_name/issues/15))"
         " ([`234`](https://github.com/owner/repo_name/"
         "commit/234))\n"
         "\n"
@@ -47,7 +47,7 @@ def test_markdown_changelog():
         " ([`21`](https://github.com/owner/repo_name/commit/21))\n"
         "\n"
         "### Documentation\n"
-        "* Document super-feature ([#189](https://github.com/owner/repo_name/pull/189))"
+        "* Document super-feature ([#189](https://github.com/owner/repo_name/issues/189))"
         " ([`0`](https://github.com/owner/repo_name/commit/0))"
     )
 
@@ -100,7 +100,7 @@ def test_changelog_table():
         "| --- | --- |\n"
         "| Feature | commit1 ([`sha1`](https://github.com/owner/repo_name/commit/sha1))"
         "<br>commit2 ([`sha2`](https://github.com/owner/repo_name/commit/sha2)) |\n"
-        "| Fix | commit3 ([#123](https://github.com/owner/repo_name/pull/123))"
+        "| Fix | commit3 ([#123](https://github.com/owner/repo_name/issues/123))"
         " ([`sha3`](https://github.com/owner/repo_name/commit/sha3)) |\n"
     )
 
@@ -151,7 +151,7 @@ def test_get_changelog_sections():
         (
             "test (#123)",
             "github",
-            "test ([#123](https://github.com/owner/name/pull/123))",
+            "test ([#123](https://github.com/owner/name/issues/123))",
         ),
         ("test without commit", "github", "test without commit"),
         ("test (#123) in middle", "github", "test (#123) in middle"),


### PR DESCRIPTION
While, e.g., https://github.com/owner/repos/pull/123 will work, https://github.com/owner/repos/issues/123 should be safer / more consistent, and should avoid a failure if someone adds an issue link at the end of a PR that is merged via rebase merge or merge commit.