### PR TITLE
feat: add `upload_to_pypi_glob_patterns` option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -339,6 +339,14 @@ Distributions
 If set to false the pypi uploading will be disabled.
 See :ref:`env-pypi_token` which must also be set for this to work.
 
+.. _config-upload_to_pypi_glob_patterns:
+
+``upload_to_pypi_glob_patterns``
+------------------
+A comma `,` separated list of glob patterns to use when uploading to pypi.
+
+Default: `*`
+
 .. _config-upload_to_release:
 
 ``upload_to_release``

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -260,7 +260,11 @@ def publish(**kwargs):
         dist_path = config.get("dist_path")
         remove_dist = config.get("remove_dist")
         upload_pypi = config.get("upload_to_pypi")
+        upload_to_pypi_glob_patterns = config.get("upload_to_pypi_glob_patterns")
         upload_release = config.get("upload_to_release")
+
+        if upload_to_pypi_glob_patterns:
+            upload_to_pypi_glob_patterns = upload_to_pypi_glob_patterns.split(",")
 
         if upload_pypi or upload_release:
             # We need to run the command to build wheels for releasing
@@ -276,6 +280,7 @@ def publish(**kwargs):
                 path=dist_path,
                 # If we are retrying, we don't want errors for files that are already on PyPI.
                 skip_existing=retry,
+                glob_patterns=upload_to_pypi_glob_patterns
             )
 
         if check_token():

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -52,6 +52,15 @@ class PypiTests(TestCase):
             [mock.call("twine upload -u '__token__' -p 'pypi-x'  \"custom-dist/*\"")],
         )
 
+    @mock.patch("semantic_release.pypi.run")
+    @mock.patch.dict("os.environ", {"PYPI_TOKEN": "pypi-x"})
+    def test_upload_with_custom_globs(self, mock_run):
+        upload_to_pypi(glob_patterns=["*.tar.gz", "*.whl"])
+        self.assertEqual(
+            mock_run.call_args_list,
+            [mock.call("twine upload -u '__token__' -p 'pypi-x'  \"dist/*.tar.gz\" \"dist/*.whl\"")],
+        )
+
     @mock.patch.dict("os.environ", {"PYPI_TOKEN": "invalid"})
     def test_raises_error_when_token_invalid(self):
         with self.assertRaises(ImproperConfigurationError):


### PR DESCRIPTION
In my use case, the build_command generates some binary files with pyinstaller that should not be uploaded to PyPI (but should still be uploaded in Github Release page).

This change allow to specify some globs that should be sent to PyPI, instead of hardcoded `*`.

```
upload_to_pypi_glob_patterns = *.tar.gz,*.whl
```