### PR TITLE
Ensure GitHub content type is always defined (application/octet-stream)

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -253,11 +253,15 @@ class Github(Base):
         """
         url = "https://uploads.github.com/repos/{owner}/{repo}/releases/{id}/assets"
 
+        content_type = mimetypes.guess_type(file, strict=False)[0]
+        if not content_type:
+            content_type = "application/octet-stream"
+
         response = requests.post(
             url.format(owner=owner, repo=repo, id=release_id),
             params={"name": os.path.basename(file), "label": label},
             headers={
-                "Content-Type": mimetypes.guess_type(file, strict=False)[0],
+                "Content-Type": content_type,
             },
             auth=Github.auth(),
             data=open(file, "rb").read(),
@@ -272,7 +276,7 @@ class Github(Base):
         try:
             response.raise_for_status()
             return True
-        except HTTPError as e:
+        except requests.exceptions.HTTPError as e:
             logger.warning(f"The github file upload {file} has failed: {e}")
             return False
 

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -268,7 +268,13 @@ class Github(Base):
             )
         )
         logger.debug(response.json())
-        return response.status_code == 201
+
+        try:
+            response.raise_for_status()
+            return True
+        except HTTPError as e:
+            logger.warning(f"The github file upload {file} has failed: {e}")
+            return False
 
     @classmethod
     def upload_dists(cls, owner: str, repo: str, version: str, path: str) -> bool:


### PR DESCRIPTION
If an error occurs while uploading files to github release, it's now logged as a warning and use raise_for_status feature from python request lib.

This fix issue when uploading files without extension to github. In this case, mimetype can't be guessed. Then, a POST request is performed without Content-Type header, but it fails with an error response from Github API.