### PR TITLE
fix(logs): Fix TypeError when enabling debug logs

### DIFF
--- a/semantic_release/changelog/changelog.py
+++ b/semantic_release/changelog/changelog.py
@@ -54,7 +54,7 @@ def changelog_headers(
 
     for section in get_changelog_sections(changelog, changelog_sections):
         # Add a header for this section
-        output += "\n### {0}\n".format(section.capitalize())
+        output += f"\n### {section.capitalize()}\n"
 
         # Add each commit from the section in an unordered list
         for item in changelog[section]:

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -100,7 +100,7 @@ def version(*, retry=False, noop=False, force_level=None, **kwargs):
     # Get the current version number
     try:
         current_version = get_current_version()
-        logger.info("Current version: {0}".format(current_version))
+        logger.info(f"Current version: {current_version}")
     except GitError as e:
         logger.error(str(e))
         return False
@@ -312,7 +312,7 @@ def filter_output_for_secrets(message):
     for secret_name in SECRET_NAMES:
         secret = os.environ.get(secret_name)
         if secret != "" and secret is not None:
-            output = output.replace(secret, "${}".format(secret_name))
+            output = output.replace(secret, f"${secret_name}")
 
     return output
 
@@ -335,11 +335,11 @@ def entry():
 @click.group()
 @common_options
 def main(**kwargs):
-    logger.debug("Main args:", kwargs)
+    logger.debug(f"Main args: {kwargs}")
     message = ""
     for secret_name in SECRET_NAMES:
-        message += '{}="{}",'.format(secret_name, os.environ.get(secret_name))
-    logger.debug("Environment:", filter_output_for_secrets(message))
+        message += f'{secret_name}="{os.environ.get(secret_name)}",'
+    logger.debug(f"Environment: {filter_output_for_secrets(message)}")
 
     obj = {}
     for key in [
@@ -353,7 +353,7 @@ def main(**kwargs):
         "version_source",
     ]:
         obj[key] = config.get(key)
-    logger.debug("Main config:", obj)
+    logger.debug(f"Main config: {obj}")
 
 
 @main.command(name="publish", help=publish.__doc__)

--- a/semantic_release/helpers.py
+++ b/semantic_release/helpers.py
@@ -40,11 +40,7 @@ class LoggedFunction:
 
             # Log result
             if result is not None:
-                self.logger.debug(
-                    "{function} -> {result}".format(
-                        function=func.__name__, result=result
-                    )
-                )
+                self.logger.debug(f"{func.__name__} -> {result}")
             return result
 
         return logged_func

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -45,7 +45,7 @@ class VersionPattern:
         variable name.
         """
         path, variable = config_str.split(":", 1)
-        pattern = r'{0} *[:=] *["\']{1}["\']'.format(variable, cls.version_regex)
+        pattern = rf'{variable} *[:=] *["\']{cls.version_regex}["\']'
         return cls(path, pattern)
 
     @classmethod
@@ -175,7 +175,7 @@ def get_new_version(current_version: str, level_bump: str) -> str:
     if not level_bump:
         logger.debug("No bump requested, returning input version")
         return current_version
-    return getattr(semver, "bump_{0}".format(level_bump))(current_version)
+    return getattr(semver, f"bump_{level_bump}")(current_version)
 
 
 @LoggedFunction(logger)
@@ -188,19 +188,19 @@ def get_previous_version(version: str) -> Optional[str]:
     """
     found_version = False
     for commit_hash, commit_message in get_commit_log():
-        logger.debug("Checking commit {}".format(commit_hash))
+        logger.debug(f"Checking commit {commit_hash}")
         if version in commit_message:
             found_version = True
-            logger.debug('Found version in commit "{}"'.format(commit_message))
+            logger.debug(f'Found version in commit "{commit_message}"')
             continue
 
         if found_version:
             matches = re.match(r"v?(\d+.\d+.\d+)", commit_message)
             if matches:
-                logger.debug("Version matches regex", commit_message)
+                logger.debug(f"Version matches regex {commit_message}")
                 return matches.group(1).strip()
 
-    return get_last_version([version, "v{}".format(version)])
+    return get_last_version([version, f"v{version}"])
 
 
 @LoggedFunction(logger)

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -36,15 +36,11 @@ def evaluate_version_bump(current_version: str, force: str = None) -> Optional[s
     changes = []
     commit_count = 0
 
-    for _hash, commit_message in get_commit_log("v{0}".format(current_version)):
+    for _hash, commit_message in get_commit_log(f"v{current_version}"):
         if commit_message.startswith(current_version):
             # Stop once we reach the current version
             # (we are looping in the order of newest -> oldest)
-            logger.debug(
-                '"{}" is commit for {}, breaking loop'.format(
-                    commit_message, current_version
-                )
-            )
+            logger.debug(f'"{commit_message}" is commit for {current_version}, breaking loop')
             break
 
         commit_count += 1
@@ -97,7 +93,7 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
 
     rev = None
     if from_version:
-        rev = "v{0}".format(from_version)
+        rev = f"v{from_version}"
 
     found_the_release = to_version is None
     for _hash, commit_message in get_commit_log(rev):

--- a/semantic_release/history/parser_angular.py
+++ b/semantic_release/history/parser_angular.py
@@ -58,7 +58,7 @@ def parse_commit_message(message: str) -> ParsedCommit:
     parsed = re_parser.match(message)
     if not parsed:
         raise UnknownCommitMessageStyleError(
-            "Unable to parse the given commit message: {}".format(message)
+            f"Unable to parse the given commit message: {message}"
         )
 
     if parsed.group("text"):

--- a/semantic_release/history/parser_tag.py
+++ b/semantic_release/history/parser_tag.py
@@ -32,7 +32,7 @@ def parse_commit_message(
     parsed = re_parser.match(message)
     if not parsed:
         raise UnknownCommitMessageStyleError(
-            "Unable to parse the given commit message: {0}".format(message)
+            f"Unable to parse the given commit message: {message}"
         )
 
     subject = parsed.group("subject")
@@ -53,7 +53,7 @@ def parse_commit_message(
     else:
         # We did not find any tags in the commit message
         raise UnknownCommitMessageStyleError(
-            "Unable to parse the given commit message: {0}".format(message)
+            f"Unable to parse the given commit message: {message}"
         )
 
     if parsed.group("text"):

--- a/semantic_release/pypi.py
+++ b/semantic_release/pypi.py
@@ -52,8 +52,8 @@ def upload_to_pypi(
         ['"{}/{}"'.format(path, glob_pattern.strip()) for glob_pattern in glob_patterns]
     )
 
+    skip_existing_param = " --skip-existing" if skip_existing else ""
+
     run(
-        "twine upload -u '{}' -p '{}' {} {}".format(
-            username, password, "--skip-existing" if skip_existing else "", dist
-        )
+        f"twine upload -u '{username}' -p '{password}'{skip_existing_param} {dist}"
     )

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -90,7 +90,7 @@ def current_commit_parser() -> Callable:
         # The final part is the name of the parse function
         return getattr(importlib.import_module(module), parts[-1])
     except (ImportError, AttributeError) as error:
-        raise ImproperConfigurationError('Unable to import parser "{}"'.format(error))
+        raise ImproperConfigurationError(f'Unable to import parser "{error}"')
 
 
 def current_changelog_components() -> List[Callable]:

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -43,12 +43,10 @@ def get_commit_log(from_rev=None):
     if from_rev:
         try:
             repo.commit(from_rev)
-            rev = "...{from_rev}".format(from_rev=from_rev)
+            rev = f"...{from_rev}"
         except BadName:
             logger.debug(
-                "Reference {} does not exist, considering entire history".format(
-                    from_rev
-                )
+                f"Reference {from_rev} does not exist, considering entire history"
             )
 
     for commit in repo.iter_commits(rev):
@@ -203,7 +201,7 @@ def tag_new_version(version: str):
 
     :param version: The version number used in the tag as a string.
     """
-    return repo.git.tag("-a", "v{0}".format(version), m="v{0}".format(version))
+    return repo.git.tag("-a", f"v{version}", m=f"v{version}")
 
 
 @check_repo
@@ -232,16 +230,9 @@ def push_new_version(
             token = "gitlab-ci-token:" + token
         actor = os.environ.get("GITHUB_ACTOR")
         if actor:
-            server = "https://{actor}:{token}@{server_url}/{owner}/{name}.git".format(
-                token=token, server_url=domain, owner=owner, name=name, actor=actor
-            )
+            server = f"https://{actor}:{token}@{domain}/{owner}/{name}.git"
         else:
-            server = "https://{token}@{server_url}/{owner}/{name}.git".format(
-                token=token,
-                server_url=domain,
-                owner=owner,
-                name=name,
-            )
+            server = f"https://{token}@{domain}/{owner}/{name}.git"
 
     try:
         repo.git.push(server, branch)

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -15,7 +15,7 @@ class PypiTests(TestCase):
         upload_to_pypi()
         self.assertEqual(
             mock_run.call_args_list,
-            [mock.call("twine upload -u 'username' -p 'password'  \"dist/*\"")],
+            [mock.call("twine upload -u 'username' -p 'password' \"dist/*\"")],
         )
 
     @mock.patch("semantic_release.pypi.run")
@@ -24,7 +24,7 @@ class PypiTests(TestCase):
         upload_to_pypi()
         self.assertEqual(
             mock_run.call_args_list,
-            [mock.call("twine upload -u '__token__' -p 'pypi-x'  \"dist/*\"")],
+            [mock.call("twine upload -u '__token__' -p 'pypi-x' \"dist/*\"")],
         )
 
     @mock.patch("semantic_release.pypi.run")
@@ -40,7 +40,7 @@ class PypiTests(TestCase):
         upload_to_pypi()
         self.assertEqual(
             mock_run.call_args_list,
-            [mock.call("twine upload -u '__token__' -p 'pypi-x'  \"dist/*\"")],
+            [mock.call("twine upload -u '__token__' -p 'pypi-x' \"dist/*\"")],
         )
 
     @mock.patch("semantic_release.pypi.run")
@@ -49,7 +49,7 @@ class PypiTests(TestCase):
         upload_to_pypi(path="custom-dist")
         self.assertEqual(
             mock_run.call_args_list,
-            [mock.call("twine upload -u '__token__' -p 'pypi-x'  \"custom-dist/*\"")],
+            [mock.call("twine upload -u '__token__' -p 'pypi-x' \"custom-dist/*\"")],
         )
 
     @mock.patch("semantic_release.pypi.run")
@@ -60,7 +60,7 @@ class PypiTests(TestCase):
             mock_run.call_args_list,
             [
                 mock.call(
-                    "twine upload -u '__token__' -p 'pypi-x'  \"dist/*.tar.gz\" \"dist/*.whl\""
+                    "twine upload -u '__token__' -p 'pypi-x' \"dist/*.tar.gz\" \"dist/*.whl\""
                 )
             ],
         )


### PR DESCRIPTION
Some logger invocation were raising "TypeError: not all arguments converted during string formatting", because of invalid argument count given.

This also refactor some other logs to use f-strings.