### PR TITLE
fix(netrc): Prefer using token defined in GH_TOKEN instead of .netrc …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "invoke>=1.4.1,<2",
         "semver>=2.8,<3",
         "twine>=3,<4",
-        "requests>=2.21,<3",
+        "requests>=2.25,<3",
         "wheel",
         "toml~=0.10.0",
         "python-gitlab>=1.10,<2",


### PR DESCRIPTION
…file

.netrc file will only be used when available and no GH_TOKEN environment variable is defined.

This also add a test to make sure .netrc is used properly when no GH_TOKEN is defined.