### PR TITLE
fix(history): require semver >= 2.10

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -175,7 +175,7 @@ def get_new_version(current_version: str, level_bump: str) -> str:
     if not level_bump:
         logger.debug("No bump requested, returning input version")
         return current_version
-    return getattr(semver, f"bump_{level_bump}")(current_version)
+    return semver.VersionInfo.parse(current_version).next_version(part=level_bump)
 
 
 @LoggedFunction(logger)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "click_log>=0.3,<1",
         "gitpython>=3.0.8,<4",
         "invoke>=1.4.1,<2",
-        "semver>=2.8,<3",
+        "semver>=2.10,<3",
         "twine>=3,<4",
         "requests>=2.25,<3",
         "wheel",


### PR DESCRIPTION
This resolves deprecation warnings, and updates this to a more 3.x compatible syntax