### PR TITLE
fix(history): coerce version to string

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -175,7 +175,7 @@ def get_new_version(current_version: str, level_bump: str) -> str:
     if not level_bump:
         logger.debug("No bump requested, returning input version")
         return current_version
-    return semver.VersionInfo.parse(current_version).next_version(part=level_bump)
+    return str(semver.VersionInfo.parse(current_version).next_version(part=level_bump))
 
 
 @LoggedFunction(logger)

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -72,6 +72,7 @@ class TestGetNewVersion:
         assert get_new_version("10.1.0", "major") == "11.0.0"
 
     def test_minor_bump(self):
+        assert type(get_new_version("0.0.0", "minor")) is str
         assert get_new_version("0.0.0", "minor") == "0.1.0"
         assert get_new_version("1.2.0", "minor") == "1.3.0"
         assert get_new_version("1.2.1", "minor") == "1.3.0"


### PR DESCRIPTION
The changes in #297 mistakenly omitted coercing the return value to a
string. This resulted in errors like:
`can only concatenate str (not "VersionInfo") to str`

Add test case asserting it's type `str`