### PR TITLE
feat: add toml files support for version declaration (#245, #275)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -49,6 +49,15 @@ specify multiple versions:
         'docs/conf.py:version',
     ]
 
+.. _config-version_toml:
+
+``version_toml``
+-------------------
+Similar to :ref:`config-version_variable`, but allows the version number to be
+identified safely in a toml file like ``pyproject.toml``, using a dotted notation to the key path::
+
+    pyproject.toml:poetry.tool.version
+
 .. _config-version_pattern:
 
 ``version_pattern``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,12 +28,14 @@ your project, for example ``setup.py``::
    )
 
 Python Semantic Release is configured using ``setup.cfg`` or ``pyproject.toml``.
-Set :ref:`config-version_variable` to the location of your version variable::
+Set :ref:`config-version_variable` to the location of your version variable inside any python file::
 
    [semantic_release]
    version_variable = setup.py:__version__
 
 .. seealso::
+   - :ref:`config-version_toml` - use `tomlkit <https://github.com/sdispater/tomlkit>`_ to read and update
+     the version number in a TOML file.
    - :ref:`config-version_pattern` - use regular expressions to keep the
      version number in a different format.
    - :ref:`config-version_source` - store the version using Git tags.

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -130,7 +130,7 @@ def commit_new_version(version: str):
 
     :param version: Version number to be used in the commit message.
     """
-    from .history import load_version_patterns
+    from .history import load_version_declarations
 
     commit_subject = config.get("commit_subject")
     message = commit_subject.format(version=version)
@@ -146,8 +146,8 @@ def commit_new_version(version: str):
         "semantic-release <semantic-release>",
     )
 
-    for pattern in load_version_patterns():
-        git_path = PurePath(os.getcwd(), pattern.path).relative_to(repo.working_dir)
+    for declaration in load_version_declarations():
+        git_path = PurePath(os.getcwd(), declaration.path).relative_to(repo.working_dir)
         repo.git.add(str(git_path))
 
     return repo.git.commit(m=message, author=commit_author)

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,9 @@ setup(
         "twine>=3,<4",
         "requests>=2.25,<3",
         "wheel",
-        "toml~=0.10.0",
         "python-gitlab>=1.10,<2",
+        "tomlkit>=0.7.0,<1.0.0",
+        "dotty-dict>=1.3.0,<2",
     ],
     extras_require={
         "test": [

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,7 @@ import os
 import platform
 from unittest import TestCase
 
-import toml
+import tomlkit
 
 from semantic_release.errors import ImproperConfigurationError
 from semantic_release.history import parser_angular
@@ -46,18 +46,16 @@ class ConfigTests(TestCase):
         # create temporary toml config file
         dummy_conf_path = os.path.join(temp_dir, "pyproject.toml")
         os.makedirs(os.path.dirname(dummy_conf_path), exist_ok=True)
-        toml_conf_content = {
-            "tool": {
-                "foo": {"bar": "baz"},
-                "semantic_release": {
-                    "upload_to_pypi": False,
-                    "version_source": "tag",
-                    "foo": "bar",
-                },
-            },
-        }
+        toml_conf_content = '''
+[tool.foo]
+bar = "baz"
+[tool.semantic_release]
+upload_to_pypi = false
+version_source = "tag"
+foo = "bar"
+'''
         with open(dummy_conf_path, "w") as dummy_conf_file:
-            toml.dump(toml_conf_content, dummy_conf_file)
+            dummy_conf_file.write(toml_conf_content)
 
         config = _config()
         mock_getcwd.assert_called_once_with()
@@ -86,7 +84,8 @@ class ConfigTests(TestCase):
 
         _ = _config()
         mock_getcwd.assert_called_once_with()
-        mock_debug.assert_called_once_with("Could not decode pyproject.toml")
+        mock_debug.assert_called_once_with(
+            'Could not decode pyproject.toml: Invalid key "TITLE OF BAD TOML" at line 1 col 25')
         # delete temporary toml config file
         os.remove(dummy_conf_path)
 


### PR DESCRIPTION
This introduce a new `version_toml` configuration property that behaves like `version_pattern` and `version_variable`.

For poetry support, user should now set `version_toml = pyproject.toml:tool.poetry.version`.

This introduce an ABC class, `VersionDeclaration`, that can be implemented to add other version declarations with ease.

`toml` dependency has been replaced by `tomlkit`, as this is used the library used by poetry to generate the `pyproject.toml` file, and is able to keep the ordering of data defined in the file.

Existing `VersionPattern` class has been renamed to `PatternVersionDeclaration` and now implements `VersionDeclaration`.

`load_version_patterns()` function has been renamed to `load_version_declarations()` and now return a list of `VersionDeclaration` implementations.

Close #245
Close #275