### PR TITLE
feat(print-version): add print-version command to output version

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -14,5 +14,5 @@ git config --global user.name "github-actions"
 git config --global user.email "action@github.com"
 
 # Run Semantic Release
-python -m semantic_release.cli publish -v DEBUG \
+python -m semantic_release publish -v DEBUG \
   -D commit_author="github-actions <action@github.com>"

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -24,6 +24,19 @@ Figure out the new version number, update and commit it, and create a tag.
 
 This will not push anything to any remote. All changes are local.
 
+.. _cmd-print-version:
+
+``semantic-release print-version``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Print to standard output the new version number.
+
+If the option ``--current`` is used, it will display the current version number.
+
+It can be used to retrieve the next version number in a shell script during the build, before running the effective
+release, ie. to rename a distribution binary with the effective version::
+
+    VERSION=$(semantic-release print-version)
 
 .. _cmd-publish:
 

--- a/semantic_release/__main__.py
+++ b/semantic_release/__main__.py
@@ -1,0 +1,5 @@
+
+from .cli import entry
+
+if __name__ == "__main__":
+    entry()

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -417,7 +417,7 @@ def cmd_version(**kwargs):
         exit(1)
 
 
-@main.command(name="print-version", help=version.__doc__)
+@main.command(name="print-version", help=print_version.__doc__)
 @common_options
 @click.option('--current/--next', default=False, help="Choose to output next version (default) or current one.")
 def cmd_print_version(**kwargs):

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -12,6 +12,7 @@ from .parser_helpers import re_breaking
 logger = logging.getLogger(__name__)
 
 LEVELS = {
+    0: None,
     1: "patch",
     2: "minor",
     3: "major",


### PR DESCRIPTION
This new command can be integrated in the build process before the effective release, ie. to rename some files with the version number.

Users may invoke `VERSION=$(semantic-release print-version)` to retrieve the version that will be generated during the release before it really occurs.