### PR TITLE
fix: use multiline version_pattern match in replace

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -101,7 +101,7 @@ class VersionPattern:
             ii, jj = m.span(1)
             return s[i:ii] + new_version + s[jj:j]
 
-        new_content = re.sub(self.pattern, swap_version, old_content)
+        new_content = re.sub(self.pattern, swap_version, old_content, flags=re.MULTILINE)
 
         logger.debug(
             f"Writing new version number: path={self.path!r} pattern={self.pattern!r} num_matches={n!r}"


### PR DESCRIPTION
Add multi-line regex support to the version replace function.

This change addresses issue 306: https://github.com/relekang/python-semantic-release/issues/306 and is an extension of the earlier change done here https://github.com/relekang/python-semantic-release/pull/259/commits.x