### PR TITLE
docs: fix `version_toml` example for Poetry

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -56,7 +56,7 @@ specify multiple versions:
 Similar to :ref:`config-version_variable`, but allows the version number to be
 identified safely in a toml file like ``pyproject.toml``, using a dotted notation to the key path::
 
-    pyproject.toml:poetry.tool.version
+    pyproject.toml:tool.poetry.version
 
 .. _config-version_pattern:
 


### PR DESCRIPTION
Looks like 2 parts `poetry` and `tool` were flipped in the example.

You can see a working example in [a repository from the author](https://github.com/inetum-orleans/docker-devbox-installer/blob/47d4d8f9779681e4cd5395f9af2b252151342a99/pyproject.toml#L27).

And [a failed attempt of mine](https://github.com/browniebroke/django-codemod/issues/318) by using the value from the docs, which caused [an error in Github actions](https://github.com/browniebroke/django-codemod/runs/1777220358?check_suite_focus=true#step:4:181).
