### PR TITLE
docs: correcting casing on proper noun

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Python Semantic Release
 
 |Test Status| |PyPI Version| |conda-forge version| |Read the Docs Status|
 
-Automatic Semantic Versioning for python projects. This is a python
+Automatic Semantic Versioning for Python projects. This is a Python
 implementation of `semantic-release`_ for JS by Stephan Bönnemann. If
 you find this topic interesting you should check out his `talk from
 JSConf Budapest`_.

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Python Semantic Release
 
 |Test Status| |PyPI Version| |conda-forge version| |Read the Docs Status|
 
-Automatic semantic versioning for python projects. This is a python
+Automatic Semantic Versioning for python projects. This is a python
 implementation of `semantic-release`_ for JS by Stephan Bönnemann. If
 you find this topic interesting you should check out his `talk from
 JSConf Budapest`_.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Python Semantic Release'
 
-description: 'Automatic semantic versioning for python projects'
+description: 'Automatic Semantic Versioning for python projects'
 
 inputs:
   directory:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Python Semantic Release'
 
-description: 'Automatic Semantic Versioning for python projects'
+description: 'Automatic Semantic Versioning for Python projects'
 
 inputs:
   directory:

--- a/docs/commit-log-parsing.rst
+++ b/docs/commit-log-parsing.rst
@@ -39,7 +39,7 @@ Writing your own parser
 If you think this is all well and cool, but the angular style is not for you,
 no need to worry because custom parsers are supported.
 
-A parser is basically a python function that takes the commit message as the
+A parser is basically a Python function that takes the commit message as the
 only argument and returns the information extracted from the commit. The format
 of the output should be a :py:class:`semantic_release.history.parser_helpers.ParsedCommit`
 object with the following parameters::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ your project, for example ``setup.py``::
    )
 
 Python Semantic Release is configured using ``setup.cfg`` or ``pyproject.toml``.
-Set :ref:`config-version_variable` to the location of your version variable inside any python file::
+Set :ref:`config-version_variable` to the location of your version variable inside any Python file::
 
    [semantic_release]
    version_variable = setup.py:__version__

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url="http://github.com/relekang/python-semantic-release",
     author="Rolf Erik Lekang",
     author_email="me@rolflekang.com",
-    description="Automatic semantic versioning for python projects",
+    description="Automatic Semantic Versioning for python projects",
     long_description=_read_long_description(),
     packages=find_packages(exclude=("tests",)),
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url="http://github.com/relekang/python-semantic-release",
     author="Rolf Erik Lekang",
     author_email="me@rolflekang.com",
-    description="Automatic Semantic Versioning for python projects",
+    description="Automatic Semantic Versioning for Python projects",
     long_description=_read_long_description(),
     packages=find_packages(exclude=("tests",)),
     license="MIT",


### PR DESCRIPTION
Semantic Versioning is the name of the specification. Therefore it is a proper noun. This patch corrects the incorrect casing for Semantic Versioning.