### PR TITLE
feat(checks): Add support for jenkins ci

### DIFF
--- a/semantic_release/ci_checks.py
+++ b/semantic_release/ci_checks.py
@@ -100,6 +100,21 @@ def bitbucket(branch: str):
     assert not os.environ.get("BITBUCKET_PR_ID")
 
 
+@checker
+def jenkins(branch: str):
+    """
+    Performs necessary checks to ensure that the jenkins build is one
+    that should create releases.
+
+    :param branch: The branch the environment should be running against.
+    """
+
+    branch_name = os.environ.get("BRANCH_NAME") or os.environ.get("GIT_BRANCH")
+    assert os.environ.get('JENKINS_URL') is not None
+    assert branch_name == branch
+    assert not os.environ.get("CHANGE_ID") # pull request id
+
+
 def check(branch: str = "master"):
     """
     Detects the current CI environment, if any, and performs necessary
@@ -117,5 +132,7 @@ def check(branch: str = "master"):
         circle(branch)
     elif os.environ.get("GITLAB_CI") == "true":
         gitlab(branch)
+    elif os.environ.get('JENKINS_URL') is not None:
+        jenkins(branch)
     elif "BITBUCKET_BUILD_NUMBER" in os.environ:
         bitbucket(branch)

--- a/tests/ci_checks/test_jenkins.py
+++ b/tests/ci_checks/test_jenkins.py
@@ -1,0 +1,33 @@
+import pytest
+
+from semantic_release import ci_checks
+from semantic_release.errors import CiVerificationError
+
+def test_jenkins_should_pass_if_url_set_branch_master_no_pr(monkeypatch):
+    monkeypatch.setenv("JENKINS_URL", "http://custom.jenkins.int.com")
+    monkeypatch.setenv("BRANCH_NAME", "master")
+
+    assert ci_checks.jenkins("master")
+
+
+def test_jenkins_should_pass_if_url_set_if_branch_correct_no_pr(monkeypatch):
+    monkeypatch.setenv("JENKINS_URL", "http://custom.jenkins.int.com")
+    monkeypatch.setenv("GIT_BRANCH", "foo-bar")
+
+    assert ci_checks.jenkins("foo-bar")
+
+
+def test_jenkins_should_raise_ci_verification_error_no_url(monkeypatch):
+    monkeypatch.setenv("BRANCH_NAME", "foo-bar")
+
+    with pytest.raises(CiVerificationError):
+        assert ci_checks.jenkins("foo-bar")
+
+
+def test_jenkins_should_raise_ci_verification_error_for_pr(monkeypatch):
+    monkeypatch.setenv("JENKINS_URL", "http://custom.jenkins.int.com")
+    monkeypatch.setenv("BRANCH_NAME", "foo-bar")
+    monkeypatch.setenv("CHANGE_ID", "1")
+
+    with pytest.raises(CiVerificationError):
+        assert ci_checks.jenkins("foo-bar")


### PR DESCRIPTION
Includes a ci check handler to verify jenkins.
Unlike other ci systems jenkins doesn't generally prefix things with
`JENKINS` or simply inject `JENKINS=true` Really the only thing that is
immediately identifiable is `JENKINS_URL`