### PR TITLE
feat: allow the use of .pypirc for twine uploads

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -356,6 +356,12 @@ A comma `,` separated list of glob patterns to use when uploading to pypi.
 
 Default: `*`
 
+.. _config-repository:
+
+``repository``
+------------------
+The repository (package index) to upload to. Should be a section in the ``.pypirc`` file.
+
 .. _config-upload_to_release:
 
 ``upload_to_release``

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -91,6 +91,9 @@ obtain a token is given `here <https://pypi.org/help/#apitoken>`_.
 
 See :ref:`automatic-pypi` for more about PyPI uploads.
 
+.. note::
+  If :ref:`env-pypi_password`, :ref:`env-pypi_username`, and :ref:`env-pypi_token` are not specified credentials from ``$HOME/.pypirc`` will be used.
+
 .. _env-pypi_password:
 
 ``PYPI_PASSWORD``

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1,21 +1,37 @@
+
+import os
+import tempfile
+
 from unittest import TestCase
 
 from semantic_release import ImproperConfigurationError
 from semantic_release.pypi import upload_to_pypi
 
-from . import mock
+from . import mock, wrapped_config_get
 
 
 class PypiTests(TestCase):
     @mock.patch("semantic_release.pypi.run")
     @mock.patch.dict(
-        "os.environ", {"PYPI_USERNAME": "username", "PYPI_PASSWORD": "password"}
+        "os.environ", {"PYPI_USERNAME": "username", "PYPI_PASSWORD": "password", "HOME": "/tmp/1234"}
     )
     def test_upload_with_password(self, mock_run):
         upload_to_pypi()
         self.assertEqual(
             mock_run.call_args_list,
             [mock.call("twine upload -u 'username' -p 'password' \"dist/*\"")],
+        )
+
+    @mock.patch("semantic_release.pypi.run")
+    @mock.patch.dict(
+        "os.environ", {"PYPI_USERNAME": "username", "PYPI_PASSWORD": "password", "HOME": "/tmp/1234"}
+    )
+    @mock.patch("semantic_release.pypi.config.get", wrapped_config_get(repository='corp-repo'))
+    def test_upload_with_repository(self, mock_run):
+        upload_to_pypi()
+        self.assertEqual(
+            mock_run.call_args_list,
+            [mock.call("twine upload -u 'username' -p 'password' -r 'corp-repo' \"dist/*\"")],
         )
 
     @mock.patch("semantic_release.pypi.run")
@@ -33,7 +49,7 @@ class PypiTests(TestCase):
         {
             "PYPI_TOKEN": "pypi-x",
             "PYPI_USERNAME": "username",
-            "PYPI_PASSWORD": "password",
+            "PYPI_PASSWORD": "password"
         },
     )
     def test_upload_prefers_token_over_password(self, mock_run):
@@ -65,11 +81,25 @@ class PypiTests(TestCase):
             ],
         )
 
+    @mock.patch("semantic_release.pypi.run")
+    @mock.patch.dict("os.environ", {})
+    def test_upload_with_pypirc_file_exists(self, mock_run):
+        tmpdir = tempfile.mkdtemp()
+        os.environ['HOME'] = tmpdir
+        with open(os.path.join(tmpdir, '.pypirc'), 'w') as pypirc_fp:
+            pypirc_fp.write('hello')
+        upload_to_pypi(path="custom-dist")
+        self.assertEqual(
+            mock_run.call_args_list,
+            [mock.call("twine upload  \"custom-dist/*\"")],
+        )
+
     @mock.patch.dict("os.environ", {"PYPI_TOKEN": "invalid"})
     def test_raises_error_when_token_invalid(self):
         with self.assertRaises(ImproperConfigurationError):
             upload_to_pypi()
 
+    @mock.patch.dict("os.environ", {"HOME": "/tmp/1234"})
     def test_raises_error_when_missing_credentials(self):
         with self.assertRaises(ImproperConfigurationError):
             upload_to_pypi()


### PR DESCRIPTION
Addresses #310

* Defaults to using `$HOME/.pypirc` file for credentials if `PYPI_TOKEN` or (`PYPI_USERNAME` and `PYPI_PASSWORD`) are not specified.
* Allows use of `--repository <repository>` for twine upload. This also comes from `$HOME/.pypirc`.