### PR TITLE
fix: pin tomlkit to 0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "requests>=2.25,<3",
         "wheel",
         "python-gitlab>=1.10,<3",
-        "tomlkit>=0.7.0,<1.0.0",
+        "tomlkit==0.7.0",
         "dotty-dict>=1.3.0,<2",
     ],
     extras_require={


### PR DESCRIPTION
Doesn't look like the proper fix, but [it solved the problem](https://github.com/browniebroke/netlify-builds/runs/2669817097?check_suite_focus=true#step:4:285) for me. 

Fixes #336 

