### PR TITLE
Feature: add option to omit tagging

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -182,7 +182,8 @@ def bump_version(new_version, level_bump):
         config.get("version_source") == "commit",
     ):
         commit_new_version(new_version)
-    tag_new_version(new_version)
+    if config.get("version_source") == "tag" or config.get("tag_commit"):
+        tag_new_version(new_version)
 
     logger.info(f"Bumping with a {level_bump} version to {new_version}")
 
@@ -377,6 +378,7 @@ def main(**kwargs):
         "major_on_zero",
         "upload_to_pypi",
         "version_source",
+        "no_git_tag",
     ]:
         obj[key] = config.get(key)
     logger.debug(f"Main config: {obj}")

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -23,3 +23,4 @@ changelog_sections=feature,fix,breaking,documentation,performance,:boom:,:sparkl
 changelog_file=CHANGELOG.md
 changelog_placeholder=<!--next-version-placeholder-->
 changelog_scope=true
+tag_commit=true

--- a/semantic_release/settings.py
+++ b/semantic_release/settings.py
@@ -46,6 +46,7 @@ def _config_from_ini(paths):
         "remove_dist",
         "upload_to_pypi",
         "upload_to_release",
+        "tag_commit",
     }
 
     # Iterate through the sections so that default values are applied

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,10 +96,9 @@ def test_version_by_tag_should_call_correct_functions(mocker):
     mocker.patch(
         "semantic_release.cli.config.get",
         wrapped_config_get(
-            version_source="tag",
+            version_source="tag"
         ),
     )
-    mocker.patch("semantic_release.cli.config.get", lambda *x, **y: False)
     mock_set_new_version = mocker.patch("semantic_release.cli.set_new_version")
     mock_tag_new_version = mocker.patch("semantic_release.cli.tag_new_version")
     mock_new_version = mocker.patch(
@@ -119,6 +118,36 @@ def test_version_by_tag_should_call_correct_functions(mocker):
     mock_new_version.assert_called_once_with("1.2.3", "major")
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
+
+def test_version_by_commit_without_tag_should_call_correct_functions(mocker):
+    mocker.patch(
+        "semantic_release.cli.config.get",
+        wrapped_config_get(
+            version_source="commit",
+            tag_commit=False
+        ),
+    )
+    mock_set_new_version = mocker.patch("semantic_release.cli.set_new_version")
+    mock_tag_new_version = mocker.patch("semantic_release.cli.tag_new_version")
+    mock_commit_new_version = mocker.patch("semantic_release.cli.commit_new_version")
+    mock_new_version = mocker.patch(
+        "semantic_release.cli.get_new_version", return_value="2.0.0"
+    )
+    mock_evaluate_bump = mocker.patch(
+        "semantic_release.cli.evaluate_version_bump", return_value="major"
+    )
+    mock_current_version = mocker.patch(
+        "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+
+    version()
+
+    mock_current_version.assert_called_once_with()
+    mock_evaluate_bump.assert_called_once_with("1.2.3", None)
+    mock_new_version.assert_called_once_with("1.2.3", "major")
+    mock_set_new_version.assert_called_once_with("2.0.0")
+    mock_commit_new_version.assert_called_once_with("2.0.0")
+    assert not mock_tag_new_version.called
 
 
 def test_force_major(mocker, runner):


### PR DESCRIPTION
I'm trying to use `python-semantic-release` in a monorepo, where I need to version individual libraries separately. This sadly gets blocked `python-semantic-release`: Some libraries could have the same version and while versioning would like to create the same (an existing) tag.

This PR solves this problem (the easy way for now) by adding an option to omit the tagging of commits. This obviously only works with the `version_source="commit"` option.

I'm relatively new to python, so any feedback on the implementation is highly appreciated :)

OT: it would be nice if `python-semantic-release` would support custom version string formats, e.g. like [lerna](https://github.com/lerna/lerna/tree/main/commands/version) for js does - this would enable alpha, beta, canary releases as well as custom version tags for individual libs in monorepos.
Should this be an interesting option, I would create a real issue for this and would throw in my dev hands to implement this :) 