### PR TITLE
Refactor `VersionDeclaration` to use `pathlib`

### DIFF
--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from textwrap import dedent
 
 import mock
@@ -107,7 +108,7 @@ class TestVersionPattern:
         [
             (
                 "path:__version__",
-                "path",
+                Path("path"),
                 r'__version__ *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']',
             ),
         ],
@@ -120,8 +121,8 @@ class TestVersionPattern:
     @pytest.mark.parametrize(
         "str, path, pattern",
         [
-            ("path:pattern", "path", r"pattern"),
-            ("path:Version: {version}", "path", r"Version: (\d+\.\d+(?:\.\d+)?)"),
+            ("path:pattern", Path("path"), r"pattern"),
+            ("path:Version: {version}", Path("path"), r"Version: (\d+\.\d+(?:\.\d+)?)"),
         ],
     )
     def test_from_pattern(self, str, path, pattern):
@@ -132,8 +133,8 @@ class TestVersionPattern:
     @pytest.mark.parametrize(
         "str, path, key",
         [
-            ("path:some.toml.key", "path", r"some.toml.key"),
-            ("path:some:other:toml.key", "path", r"some:other:toml.key"),
+            ("path:some.toml.key", Path("path"), r"some.toml.key"),
+            ("path:some:other:toml.key", Path("path"), r"some:other:toml.key"),
         ],
     )
     def test_from_toml(self, str, path, key):
@@ -207,15 +208,15 @@ class TestVersionPattern:
     @pytest.mark.parametrize(
         "key, content, hits",
         [
-            (r"root", 'root = "test"', {"test"}),
-            (r"tool.poetry.version", '[tool.poetry]\nversion = "0.1.0"', {"0.1.0"}),
+            ("root", 'root = "test"', {"test"}),
+            ("tool.poetry.version", '[tool.poetry]\nversion = "0.1.0"', {"0.1.0"}),
         ],
     )
     def test_toml_parse(self, tmp_path, key, content, hits):
         path = tmp_path / "pyproject.toml"
         path.write_text(content)
 
-        declaration = TomlVersionDeclaration(str(path), key)
+        declaration = TomlVersionDeclaration(path, key)
         assert declaration.parse() == hits
 
     @pytest.mark.parametrize(
@@ -308,7 +309,7 @@ class TestVersionPattern:
                         version_variable = "path:__version__"
                         """,
             patterns=[
-                ("path", r'__version__ *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path"), r'__version__ *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -317,8 +318,8 @@ class TestVersionPattern:
                         version_variable = "path1:var1,path2:var2"
                         """,
             patterns=[
-                ("path1", r'var1 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
-                ("path2", r'var2 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path1"), r'var1 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path2"), r'var2 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -330,8 +331,8 @@ class TestVersionPattern:
                         ]
                         """,
             patterns=[
-                ("path1", r'var1 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
-                ("path2", r'var2 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path1"), r'var1 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path2"), r'var2 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -340,7 +341,7 @@ class TestVersionPattern:
                         version_pattern = "path:pattern"
                         """,
             patterns=[
-                ("path", "pattern"),
+                (Path("path"), "pattern"),
             ],
         ),
         dict(
@@ -349,8 +350,8 @@ class TestVersionPattern:
                         version_pattern = "path1:pattern1,path2:pattern2"
                         """,
             patterns=[
-                ("path1", "pattern1"),
-                ("path2", "pattern2"),
+                (Path("path1"), "pattern1"),
+                (Path("path2"), "pattern2"),
             ],
         ),
         dict(
@@ -362,8 +363,8 @@ class TestVersionPattern:
                         ]
                         """,
             patterns=[
-                ("path1", "pattern1"),
-                ("path2", "pattern2"),
+                (Path("path1"), "pattern1"),
+                (Path("path2"), "pattern2"),
             ],
         ),
     ],

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -224,17 +224,58 @@ class TestVersionPattern:
             (r"root", "", ""),
             (r"root", 'root = "test"', 'root = "-"'),
             (
-                r"tool.poetry.version",
-                "[tool.poetry]\n"
-                'version = "0.1.0"\n'
-                "[tool.poetry.dependencies.pylint]\n"
-                'version = "^2.5.3"\n'
-                "optional = true\n",
-                "[tool.poetry]\n"
-                'version = "-"\n'
-                "[tool.poetry.dependencies.pylint]\n"
-                'version = "^2.5.3"\n'
-                "optional = true\n",
+                "tool.poetry.version",
+                dedent(
+                    """
+                    [tool.poetry]
+                    version = "0.1.0"
+                    [tool.poetry.dependencies.pylint]
+                    version = "^2.5.3"
+                    optional = true
+                    """
+                ),
+                dedent(
+                    """
+                    [tool.poetry]
+                    version = "-"
+                    [tool.poetry.dependencies.pylint]
+                    version = "^2.5.3"
+                    optional = true
+                    """
+                ),
+            ),
+            (
+                "tool.poetry.version",
+                dedent(
+                    """
+                    [tool.poetry]
+                    name = "my-package"
+                    version = "0.1.0"
+                    description = "A super package"
+                    
+                    [build-system]
+                    requires = ["poetry-core>=1.0.0"]
+                    build-backend = "poetry.core.masonry.api"
+                    
+                    [tool.semantic_release]
+                    version_toml = "pyproject.toml:tool.poetry.version"
+                    """
+                ),
+                dedent(
+                    """
+                    [tool.poetry]
+                    name = "my-package"
+                    version = "-"
+                    description = "A super package"
+                    
+                    [build-system]
+                    requires = ["poetry-core>=1.0.0"]
+                    build-backend = "poetry.core.masonry.api"
+                    
+                    [tool.semantic_release]
+                    version_toml = "pyproject.toml:tool.poetry.version"
+                    """
+                ),
             ),
         ],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -825,7 +825,9 @@ def test_changelog_should_call_functions(mocker, runner):
 
 
 def test_overload_by_cli(mocker, runner):
-    mock_open = mocker.patch("semantic_release.history.open", mock_version_file)
+    mock_read_text = mocker.patch(
+        "semantic_release.history.Path.read_text", mock_version_file
+    )
     runner.invoke(
         main,
         [
@@ -837,8 +839,8 @@ def test_overload_by_cli(mocker, runner):
         ],
     )
 
-    mock_open.assert_called_once_with("my_version_path", "r")
-    mock_open.reset_mock()
+    mock_read_text.assert_called_once_with()
+    mock_read_text.reset_mock()
 
 
 def test_changelog_noop(mocker):


### PR DESCRIPTION
This extracts some refactoring out of #346 which I think are beneficials:

- Refactor `VersionDeclaration` to use `pathlib`
- Add a test to reproduce the out-of-order issue with `tomlkit` 0.7.2 + dotty-dict

