### PR TITLE
feat(parser): add scipy style parser

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -19,6 +19,7 @@ from .logs import evaluate_version_bump  # noqa
 
 from .parser_angular import parse_commit_message as angular_parser  # noqa isort:skip
 from .parser_emoji import parse_commit_message as emoji_parser  # noqa isort:skip
+from .parser_scipy import parse_commit_message as scipy_parser  # noqa isort:skip
 from .parser_tag import parse_commit_message as tag_parser  # noqa isort:skip
 
 logger = logging.getLogger(__name__)

--- a/semantic_release/history/parser_scipy.py
+++ b/semantic_release/history/parser_scipy.py
@@ -142,8 +142,8 @@ def parse_commit_message(message: str) -> ParsedCommit:
     else:
         blocks = [subject]
 
+    msg_type: ChangeType
     for msg_type in COMMIT_TYPES:
-        msg_type: ChangeType
         if msg_type.tag == parsed.group("tag"):
             break
     else:

--- a/semantic_release/history/parser_scipy.py
+++ b/semantic_release/history/parser_scipy.py
@@ -1,0 +1,129 @@
+"""
+Scipy commit style parser
+
+Parses commit messages of the following forms
+
+```
+<tag>: <subject>
+
+<body>
+```
+
+Both <tag> and <body> are optional. If <tag> is missing, then the commit message
+should be of the form
+
+```
+<subject>
+
+<body>
+```
+
+again with an optional body. Releases will only be generated for tagged commits
+or commits.
+
+https://docs.scipy.org/doc/scipy/reference/dev/contributor/continuous_integration.html#continuous-integration
+"""
+import logging
+import re
+from dataclasses import dataclass
+from semantic_release.history.parser_angular import MINOR_TYPES
+
+from ..errors import UnknownCommitMessageStyleError
+from ..helpers import LoggedFunction
+from .parser_helpers import ParsedCommit, parse_paragraphs, re_breaking
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChangeType:
+    tag: str
+    description: str
+    bump_level: int = 0
+
+    def make_breaking(self):
+        self.bump_level = 3
+
+
+@dataclass
+class Breaking(ChangeType):
+    bump_level: int = 3
+
+
+@dataclass
+class Compatible(ChangeType):
+    bump_level: int = 2
+
+
+@dataclass
+class Patch(ChangeType):
+    bump_level: int = 1
+
+
+@dataclass
+class Ignore(ChangeType):
+    bump_level: int = 0
+
+
+COMMIT_TYPES = [
+    Breaking("API", "an (incompatible) API change"),
+    Compatible("DEP", "deprecate something, or remove a deprecated object"),
+    Compatible("ENH", "enhancement"),
+    Compatible("REV", "revert an earlier commit"),
+    Patch("BUG", "bug fix"),
+    Ignore("MAINT", "maintenance commit (refactoring, typos, etc.)"),
+    Ignore("BENCH", "changes to the benchmark suite"),
+    Ignore("BLD", "change related to building"),
+    Ignore("DEV", "development tool or utility"),
+    Ignore("DOC", "documentation"),
+    Ignore("STY", "style fix (whitespace, PEP8)"),
+    Ignore("TST", "addition or modification of tests"),
+    Ignore("REL", "related to releasing"),
+    
+    # strictly speaking not part of the standard
+    Compatible("FEAT", "new feature"),
+    Ignore("TEST", "addition or modification of tests"),
+]
+
+
+@LoggedFunction(logger)
+def parse_commit_message(message: str) -> ParsedCommit:
+    """
+    Parse a scipy-style commit message
+
+    :param message: A string of a commit message.
+    :return: A tuple of (level to bump, type of change, scope of change, a tuple
+    with descriptions)
+    :raises UnknownCommitMessageStyleError: if regular expression matching fails
+    """
+
+    blocks = message.split("\n\n")
+    blocks = [x for x in blocks if not x == ""]
+    header = blocks[0]
+
+    for msg_type in COMMIT_TYPES:
+        msg_type:ChangeType
+        tag = msg_type.tag
+        if header.startswith(tag):
+            header = header[len(tag):]
+            header = header[2:] if header[0] == ":" else header[0]
+            blocks[0] = header
+            break
+    else:
+        # some commits may not have an acronym if they belong to a PR that
+        # wasn't squashed (for maintainability) ignore them
+        msg_type = Ignore("", "Untagged commit.")
+
+    # Look for descriptions of breaking changes
+    # technically scipy doesn't document breaking changes explicitly
+    breaking_blocks = [block for block in blocks if block.startswith("BREAKING CHANGE")]
+    if breaking_blocks:
+        msg_type.make_breaking()
+
+    return ParsedCommit(
+        msg_type.bump_level,
+        msg_type.description,
+        None,  # scipy style doesn't use scopes
+        blocks,
+        breaking_blocks
+    )

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 from semantic_release.history.parser_scipy import COMMIT_TYPES, ChangeType
 
+
 @pytest.fixture(params=COMMIT_TYPES)
 def scipy_type(request):
     return request.param
@@ -43,11 +44,13 @@ def subject(request):
             updated-dependencies:
             - dependency-name: sphinx
             dependency-type: direct:development
-            update-type: version-update:semver-major"""
+            update-type: version-update:semver-major""",
         ),
-        ("Bug spotted on Fedora, see https://src.fedoraproject.org/rpms/scipy/pull-request/22",
-         "The `int[::]` annotation is used to accept non-contiguous views."),
-        ("[skip azp] [skip actions]",)
+        (
+            "Bug spotted on Fedora, see https://src.fedoraproject.org/rpms/scipy/pull-request/22",
+            "The `int[::]` annotation is used to accept non-contiguous views.",
+        ),
+        ("[skip azp] [skip actions]",),
     ]
 )
 def body_parts(request):
@@ -55,7 +58,7 @@ def body_parts(request):
 
 
 @pytest.fixture()
-def expected_response_scipy(scipy_type:ChangeType, subject, body_parts):
+def expected_response_scipy(scipy_type: ChangeType, subject, body_parts):
     bump_level = scipy_type.bump_level
     topic = scipy_type.section
     changelog_body = (subject, *body_parts)
@@ -63,8 +66,7 @@ def expected_response_scipy(scipy_type:ChangeType, subject, body_parts):
 
 
 @pytest.fixture()
-def valid_scipy_commit(scipy_type:ChangeType, subject, body_parts):
+def valid_scipy_commit(scipy_type: ChangeType, subject, body_parts):
     body = "\n\n".join(body_parts)
-    commit_msg = (
-    f"{scipy_type.tag}: {subject}\n\n{body}")
+    commit_msg = f"{scipy_type.tag}: {subject}\n\n{body}"
     return commit_msg

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -57,7 +57,7 @@ def body_parts(request):
 @pytest.fixture()
 def expected_response_scipy(scipy_type:ChangeType, subject, body_parts):
     bump_level = scipy_type.bump_level
-    topic = scipy_type.description
+    topic = scipy_type.section
     changelog_body = (subject, *body_parts)
     return (bump_level, topic, None, changelog_body)
 

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -1,0 +1,70 @@
+import pytest
+
+from semantic_release.history.parser_scipy import COMMIT_TYPES, ChangeType
+
+@pytest.fixture(params=COMMIT_TYPES)
+def scipy_type(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        "scipy.stats.qmc: centered-discrepancy optimization of a Latin hypercube",
+        "inverse missing in idstn, idctn (#14479)",
+        "Merge pull request #14447 from AnirudhDagar/rename_ndimage_modules",
+        "Add tests for args kwarg in quad_vec",
+        "badge with version of the doc in the navbar (#14132)",
+        "Bump scipy from 1.7.0 to 1.7.1 (#28)",
+        "avoid nan if angle=0 in RotvecRotation",
+    ]
+)
+def subject(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        # a squash merge that preserved PR commit messages
+        (
+            "DOC: import ropy.transform to test for numpy error",
+            "DOC: lower numpy version",
+            "DOC: lower numpy version further",
+            "MAINT: remove debugging import",
+        ),
+        # empty body
+        list(),
+        # formatted body
+        (
+            """Bumps [sphinx](https://github.com/sphinx-doc/sphinx) from 3.5.3 to 4.1.1.
+            - [Release notes](https://github.com/sphinx-doc/sphinx/releases)
+            - [Changelog](https://github.com/sphinx-doc/sphinx/blob/4.x/CHANGES)
+            - [Commits](https://github.com/sphinx-doc/sphinx/commits/v4.1.1)""",
+            """---
+            updated-dependencies:
+            - dependency-name: sphinx
+            dependency-type: direct:development
+            update-type: version-update:semver-major"""
+        ),
+        ("Bug spotted on Fedora, see https://src.fedoraproject.org/rpms/scipy/pull-request/22",
+         "The `int[::]` annotation is used to accept non-contiguous views."),
+        ("[skip azp] [skip actions]",)
+    ]
+)
+def body_parts(request):
+    return request.param
+
+
+@pytest.fixture()
+def expected_response_scipy(scipy_type:ChangeType, subject, body_parts):
+    bump_level = scipy_type.bump_level
+    topic = scipy_type.description
+    changelog_body = (subject, *body_parts)
+    return (bump_level, topic, None, changelog_body)
+
+
+@pytest.fixture()
+def valid_scipy_commit(scipy_type:ChangeType, subject, body_parts):
+    body = "\n\n".join(body_parts)
+    commit_msg = (
+    f"{scipy_type.tag}: {subject}\n\n{body}")
+    return commit_msg

--- a/tests/parsers/test_scipy.py
+++ b/tests/parsers/test_scipy.py
@@ -1,0 +1,14 @@
+import pytest
+
+from semantic_release.errors import UnknownCommitMessageStyleError
+from semantic_release.history import scipy_parser
+
+
+def test_valid_scipy_commit(valid_scipy_commit, expected_response_scipy):
+    (commit_tag, subject, _, body_parts) = expected_response_scipy
+    result = scipy_parser(valid_scipy_commit)
+
+    assert result[0] == commit_tag
+    assert result[1] == subject
+    assert len(result[3]) == len(body_parts)
+    assert all(a == b for a, b in zip(result[3], body_parts))


### PR DESCRIPTION
Closes: #368 

Adds a simple scipy style parser + unit tests

The tests generate a matrix of commit messages (from parts that I faithfully borrowed from my repos and scipy), and they parse correctly.

When I naively run the parser on my target repo (`semantic release -v debug changelog` in project root), however, the changelog remains empty. I can confirm that it indeed selects the scipy_parser added here, and I know that at least some of the commits should be parsed correctly (they are generated by the tests). Does python-semantic-release need an initial tagged commit to get going? If not, any other idea where I am being stupid?

**Edit:** The version appears to be detected correctly:

```bash
$ semantic-release -v debug --noop version
debug: Main args: {'force_level': None, 'post': False, 'retry': False, 'noop': False, 'define': ()}
debug: Environment: PYPI_USERNAME="None",PYPI_PASSWORD="None",GH_TOKEN="None",GL_TOKEN="None",
debug: Main config: {'check_build_status': False, 'commit_subject': '{version}', 'commit_message': 'Automatically generated by python-semantic-release', 'commit_parser': 'semantic_release.history.scipy_parser', 'patch_without_tag': False, 'major_on_zero': True, 'upload_to_pypi': True, 'version_source': 'commit', 'no_git_tag': None}
Creating new version
Current version: 0.0.2
warning: No operation mode. Should have bumped from 0.0.2 to 1.0.0
```