### PR TITLE
docs(parser): documentation for scipy-parser

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,6 +158,16 @@ The following parsers are built in to Python Semantic Release:
   The original parser from v1.0.0 of Python Semantic Release. Similar to the
   emoji parser above, but with less features.
 
+- :py:func:`semantic_release.history.scipy_parser`
+
+  A parser for `scipy-style commits <scipy-style>`_ with the following differences:
+
+    - Beginning a paragraph inside the commit with ``BREAKING CHANGE`` declares
+      a breaking change. Multiple ``BREAKING CHANGE`` paragraphs are supported.
+    - A scope (following the tag in parentheses) is supported
+
+  See :ref:`config-scipy-parser` for details.
+
 .. _config-major_emoji:
 
 ``major_emoji``
@@ -187,6 +197,14 @@ Comma-separated list of emojis used by :py:func:`semantic_release.history.emoji_
 create patch releases.
 
 Default: `:ambulance:, :lock:, :bug:, :zap:, :goal_net:, :alien:, :wheelchair:, :speech_balloon:, :mag:, :apple:, :penguin:, :checkered_flag:, :robot:, :green_apple:`
+
+.. _config-scipy-parser:
+
+``scipy_parser``
+----------------
+
+.. automodule:: semantic_release.history.parser_scipy
+
 
 Commits
 =======

--- a/semantic_release/history/parser_scipy.py
+++ b/semantic_release/history/parser_scipy.py
@@ -1,7 +1,4 @@
 """
-Scipy Style Parser
-------------------
-
 Parses commit messages using `scipy tags <scipy-style>`_ of the form::
 
     <tag>(<scope>): <subject>
@@ -13,9 +10,17 @@ The elements <tag>, <scope> and <body> are optional. If no tag is present, the
 commit will be added to the changelog section "None" and no version increment
 will be performed.
 
+While <scope> is supported here it isn't actually part of the scipy style.
+If it is missing, parentheses around it are too. The commit should then be
+of the form::
+
+    <tag>: <subject>
+
+    <body>
+
 To communicate a breaking change add "BREAKING CHANGE" into the body at the
 beginning of a paragraph. Fill this paragraph with information how to migrate
-from the broken behavior to the new behavior. This section will be added to the
+from the broken behavior to the new behavior. It will be added to the
 "Breaking" section of the changelog.
 
 Supported Tags::
@@ -26,15 +31,6 @@ Supported Tags::
 Supported Changelog Sections::
 
     breaking, feature, fix, Other, None
-
-.. note::
-    While <scope> is supported here it isn't actually part of the scipy style.
-    If it is missing, parentheses around it are too. The commit should then be
-    of the form::
-
-        <tag>: <subject>
-
-        <body>
 
 .. _`scipy-style`: https://docs.scipy.org/doc/scipy/reference/dev/contributor/development_workflow.html#writing-the-commit-message
 """


### PR DESCRIPTION
I struggle a bit navigating these docs, so I am probably committing a blunder here. I added a paragraph to the list of parsers and then referred below for details where I `..automodule:`ed the docstring that I wrote for the module.

(I then tamed the docstring to fit a little better with the existing style of the docs.)