### PR TITLE
fix: hardcoded v-prefix in the git tags

### DIFF
--- a/semantic_release/changelog/compare.py
+++ b/semantic_release/changelog/compare.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from ..settings import config
-from ..vcs_helpers import get_repository_owner_and_name
+from ..vcs_helpers import get_repository_owner_and_name, get_formatted_tag
 
 
 def get_github_compare_url(from_version: str, to_version: str) -> str:
@@ -14,7 +14,8 @@ def get_github_compare_url(from_version: str, to_version: str) -> str:
     """
     owner, name = get_repository_owner_and_name()
     return (
-        f"https://github.com/{owner}/{name}" f"/compare/v{from_version}...v{to_version}"
+        f"https://github.com/{owner}/{name}/compare/"
+        f"{get_formatted_tag(from_version)}...{get_formatted_tag(to_version)}"
     )
 
 

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -14,7 +14,7 @@ from dotty_dict import Dotty
 from ..errors import ImproperConfigurationError
 from ..helpers import LoggedFunction
 from ..settings import config
-from ..vcs_helpers import get_commit_log, get_last_version
+from ..vcs_helpers import get_commit_log, get_last_version, get_formatted_tag
 from .logs import evaluate_version_bump  # noqa
 
 from .parser_angular import parse_commit_message as angular_parser  # noqa isort:skip
@@ -265,7 +265,7 @@ def get_previous_version(version: str) -> Optional[str]:
                 logger.debug(f"Version matches regex {commit_message}")
                 return matches.group(1).strip()
 
-    return get_last_version([version, f"v{version}"])
+    return get_last_version([version, get_formatted_tag(version)])
 
 
 @LoggedFunction(logger)

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -36,7 +36,7 @@ def evaluate_version_bump(current_version: str, force: str = None) -> Optional[s
     changes = []
     commit_count = 0
 
-    for _hash, commit_message in get_commit_log(f"v{current_version}"):
+    for _hash, commit_message in get_commit_log(current_version):
         if commit_message.startswith(current_version):
             # Stop once we reach the current version
             # (we are looping in the order of newest -> oldest)
@@ -95,7 +95,7 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
 
     rev = None
     if from_version:
-        rev = f"v{from_version}"
+        rev = from_version
 
     found_the_release = to_version is None
     for _hash, commit_message in get_commit_log(rev):

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -13,6 +13,7 @@ from urllib3 import Retry
 from .errors import ImproperConfigurationError
 from .helpers import LoggedFunction, build_requests_session
 from .settings import config
+from .vcs_helpers import get_formatted_tag
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +257,7 @@ class Github(Base):
 
         :return: The status of the request
         """
-        tag = f"v{version}"
+        tag = get_formatted_tag(version)
         logger.debug(f"Attempting to create release for {tag}")
         success = Github.create_release(owner, repo, tag, changelog)
 
@@ -326,7 +327,7 @@ class Github(Base):
         """
 
         # Find the release corresponding to this version
-        release_id = Github.get_release(owner, repo, f"v{version}")
+        release_id = Github.get_release(owner, repo, get_formatted_tag(version))
         if not release_id:
             logger.debug("No release found to upload assets to")
             return False
@@ -410,7 +411,7 @@ class Gitlab(Base):
 
         :return: The status of the request
         """
-        ref = "v" + version
+        ref = get_formatted_tag(version)
         gl = gitlab.Gitlab(Gitlab.api_url(), private_token=Gitlab.token())
         gl.auth()
         try:

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -36,11 +36,18 @@ def check_repo(func):
     return function_wrapper
 
 
+def get_formatted_tag(version):
+    """Get the version, formatted with `tag_format` config option"""
+    tag_format = config.get("tag_format")
+    return tag_format.format(version=version)
+
+
 @check_repo
 def get_commit_log(from_rev=None):
     """Yield all commit messages from last to first."""
     rev = None
     if from_rev:
+        from_rev = get_formatted_tag(from_rev)
         try:
             repo.commit(from_rev)
             rev = f"...{from_rev}"
@@ -200,8 +207,7 @@ def tag_new_version(version: str):
 
     :param version: The version number used in the tag as a string.
     """
-    tag_format = config.get("tag_format")
-    tag = tag_format.format(version=version)
+    tag = get_formatted_tag(version)
     return repo.git.tag("-a", tag, m=tag)
 
 


### PR DESCRIPTION
Otherwise, hvcs release could not be created (+another side effects?) if `tag_format` config option has a non-default value