### PR TITLE
feat(parser_angular): allow customization in parser

### DIFF
--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -1,4 +1,8 @@
 [semantic_release]
+parser_angular_allowed_types=build,chore,ci,docs,feat,fix,perf,style,refactor,test
+parser_angular_default_level_bump=0
+parser_angular_minor_types=feat
+parser_angular_patch_types=fix,perf
 branch=master
 build_command=python setup.py sdist bdist_wheel
 changelog_components=semantic_release.changelog.changelog_headers

--- a/semantic_release/defaults.cfg
+++ b/semantic_release/defaults.cfg
@@ -1,6 +1,7 @@
 [semantic_release]
 parser_angular_allowed_types=build,chore,ci,docs,feat,fix,perf,style,refactor,test
-parser_angular_default_level_bump=0
+parser_angular_default_level_bump=no-release
+# valid options: no-release, patch, minor, major
 parser_angular_minor_types=feat
 parser_angular_patch_types=fix,perf
 branch=master


### PR DESCRIPTION
- `angular_parser_allowed_types` controls allowed types
  - defaults stay the same: build, chore, ci, docs, feat, fix, perf, style,
    refactor, test
- `angular_parser_default_level_bump` controls the default level to bump the
  version by
  - default stays at 0
- `angular_parser_minor_types` controls which types trigger a minor version
  bump
  - default stays at only 'feat'
- `angular_parser_patch_types` controls which types trigger a patch version
  - default stays at 'fix' or 'perf'