### PR TITLE
test: Prevent test_repo_with_custom_* from failing when run on window due to different path seperator

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -8,6 +8,8 @@ from semantic_release import ImproperConfigurationError
 from semantic_release.repository import ArtifactRepo
 from tests import wrapped_config_get
 
+import os
+
 
 class RepositoryTests(TestCase):
     @pytest.fixture(autouse=True)
@@ -111,7 +113,7 @@ class RepositoryTests(TestCase):
     @mock.patch.object(ArtifactRepo, "_handle_credentials_init")
     def test_repo_with_custom_dist_path(self, mock_handle_creds):
         repo = ArtifactRepo(Path("custom-dist"))
-        self.assertEqual(repo.dists, ["custom-dist/*"])
+        self.assertEqual(repo.dists, [os.path.join("custom-dist", "*")])
 
     @mock.patch.object(ArtifactRepo, "_handle_credentials_init")
     @mock.patch(
@@ -120,7 +122,7 @@ class RepositoryTests(TestCase):
     )
     def test_repo_with_custom_dist_globs(self, mock_handle_creds):
         repo = ArtifactRepo(Path("dist"))
-        self.assertEqual(repo.dists, ["dist/*.tar.gz", "dist/*.whl"])
+        self.assertEqual(repo.dists, [os.path.join("dist", "*.tar.gz"), os.path.join("dist", "*.whl")])
 
     @mock.patch.object(ArtifactRepo, "_handle_credentials_init")
     @mock.patch(
@@ -129,7 +131,7 @@ class RepositoryTests(TestCase):
     )
     def test_repo_with_custom_pypi_globs(self, mock_handle_creds):
         repo = ArtifactRepo(Path("dist"))
-        self.assertEqual(repo.dists, ["dist/*.tar.gz", "dist/*.whl"])
+        self.assertEqual(repo.dists, [os.path.join("dist", "*.tar.gz"), os.path.join("dist", "*.whl")])
 
     @mock.patch.object(ArtifactRepo, "_handle_credentials_init")
     @mock.patch(


### PR DESCRIPTION
When run on windows the following tests fail due to a different separator:

```
> tox
...
FAILED tests/test_repository.py::RepositoryTests::test_repo_with_custom_dist_globs - AssertionError: Lists differ: ['dist\\*.tar.gz', 'dist\\*.whl'] != ['dist/*.tar.gz', 'dist/*.whl']
FAILED tests/test_repository.py::RepositoryTests::test_repo_with_custom_dist_path - AssertionError: Lists differ: ['custom-dist\\*'] != ['custom-dist/*']
FAILED tests/test_repository.py::RepositoryTests::test_repo_with_custom_pypi_globs - AssertionError: Lists differ: ['dist\\*.tar.gz', 'dist\\*.whl'] != ['dist/*.tar.gz', 'dist/*.whl']
```

This PR should take care of that by using os.path.join() when defining expected values