### PR TITLE
chore(dependencies): extend allowed version range for python-gitlab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "twine>=3,<4",
         "requests>=2.25,<3",
         "wheel",
-        "python-gitlab>=1.10,<3",
+        "python-gitlab>=2",
         # See https://github.com/relekang/python-semantic-release/issues/336
         # and https://github.com/relekang/python-semantic-release/pull/337
         # for why tomlkit is pinned


### PR DESCRIPTION
[python-gitlab](https://github.com/python-gitlab/python-gitlab/releases) released version 3.0.0 last month

is there any reason for pining the upper version of this dependency? I can restrict it to <4 if this has proven to be useful in this project in the past 