### PR TITLE
fix(gitea): build status and asset upload

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -572,19 +572,18 @@ class Gitea(Base):
         :return: The status of the request
         """
         url = f"{Gitea.api_url()}/repos/{owner}/{repo}/releases/{release_id}/assets"
-
-        content_type = mimetypes.guess_type(file, strict=False)[0]
-        if not content_type:
-            content_type = "application/octet-stream"
-
         try:
+            name = os.path.basename(file)
             response = Gitea.session().post(
                 url,
-                params={"name": os.path.basename(file)},
+                params={"name": name},
                 headers={
-                    "Content-Type": content_type,
+                    'accept': 'application/json',
+                    'Content-Type': 'multipart/form-data',
                 },
-                data=open(file, "rb").read(),
+                files={
+                    'attachment': (name, open(file,'rb')),
+                },
             )
 
             logger.debug(

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -439,7 +439,11 @@ class Gitea(Base):
             response = Gitea.session().get(
                 url.format(domain=Gitea.api_url(), owner=owner, repo=repo, ref=ref)
             )
-            return response.json().get("state") == "success"
+            data = response.json()
+            if type(data) == list:
+                return data[0].get("status") == "success"
+            else:
+                return data.get("status") == "success"
         except HTTPError as e:
             logger.warning(f"Build status check on Gitea has failed: {e}")
             return False

--- a/tests/test_hvcs.py
+++ b/tests/test_hvcs.py
@@ -291,7 +291,7 @@ class GiteaCheckBuildStatusTests(TestCase):
     def get_response(self, status):
         return json.dumps(
             {
-                "state": status,
+                "status": status,
             }
         )
 

--- a/tests/test_hvcs.py
+++ b/tests/test_hvcs.py
@@ -695,9 +695,9 @@ class GiteaReleaseTests(TestCase):
             dummy_file.write(dummy_content)
 
         def request_callback(request):
-            self.assertEqual(request.body.decode().replace("\r\n", "\n"), dummy_content)
+            self.assertTrue(f'Content-Disposition: form-data; name="attachment"; filename="{os.path.basename(dummy_file_path)}"' in request.body.decode())
             self.assertEqual(request.url, self.asset_url_params)
-            self.assertEqual(request.headers["Content-Type"], "text/markdown")
+            self.assertEqual(request.headers["Content-Type"], 'multipart/form-data')
             self.assertEqual("token super-token", request.headers.get("Authorization"))
 
             return 201, {}, json.dumps({})
@@ -724,10 +724,10 @@ class GiteaReleaseTests(TestCase):
             dummy_file.write(dummy_content)
 
         def request_callback(request):
-            self.assertEqual(request.body.decode().replace("\r\n", "\n"), dummy_content)
+            self.assertTrue(f'Content-Disposition: form-data; name="attachment"; filename="{os.path.basename(dummy_file_path)}"' in request.body.decode())
             self.assertEqual(request.url, self.asset_no_extension_url_params)
             self.assertEqual(
-                request.headers["Content-Type"], "application/octet-stream"
+                request.headers["Content-Type"], 'multipart/form-data'
             )
             self.assertEqual("token super-token", request.headers["Authorization"])
 
@@ -755,9 +755,9 @@ class GiteaReleaseTests(TestCase):
             dummy_file.write(dummy_content)
 
         def request_callback(request):
-            self.assertEqual(request.body.decode().replace("\r\n", "\n"), dummy_content)
+            self.assertTrue(f'Content-Disposition: form-data; name="attachment"; filename="{os.path.basename(dummy_file_path)}"' in request.body.decode())
             self.assertEqual(request.url, self.dist_asset_url_params)
-            self.assertEqual(request.headers["Content-Type"], "text/markdown")
+            self.assertEqual(request.headers["Content-Type"], 'multipart/form-data')
             self.assertEqual("token super-token", request.headers.get("Authorization"))
 
             return 201, {}, json.dumps({})


### PR DESCRIPTION
 - Turns out that response from `https://gitea.com/api/swagger#/repository/repoCreateStatus` is sometimes a list 
 - Also fixes gitea asset upload