### PR TITLE
fix(gitea): use form-data for asset upload

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -577,13 +577,17 @@ class Gitea(Base):
             response = Gitea.session().post(
                 url,
                 params={"name": name},
-                headers={
-                    "accept": "application/json",
-                    "Content-Type": "multipart/form-data",
-                },
-                files={
-                    "attachment": (name, open(file, "rb")),
-                },
+                data={},
+                files=[
+                    (
+                        "attachment",
+                        (
+                            name,
+                            open(file, "rb"),
+                            "application/octet-stream",
+                        ),
+                    )
+                ],
             )
 
             logger.debug(

--- a/tests/test_hvcs.py
+++ b/tests/test_hvcs.py
@@ -695,12 +695,9 @@ class GiteaReleaseTests(TestCase):
             dummy_file.write(dummy_content)
 
         def request_callback(request):
-            self.assertTrue(
-                f'Content-Disposition: form-data; name="attachment"; filename="{os.path.basename(dummy_file_path)}"'
-                in request.body.decode()
-            )
+            self.assertTrue(dummy_content in request.body.decode())
             self.assertEqual(request.url, self.asset_url_params)
-            self.assertEqual(request.headers["Content-Type"], "multipart/form-data")
+            self.assertTrue("multipart/form-data" in request.headers["Content-Type"])
             self.assertEqual("token super-token", request.headers.get("Authorization"))
 
             return 201, {}, json.dumps({})
@@ -727,12 +724,9 @@ class GiteaReleaseTests(TestCase):
             dummy_file.write(dummy_content)
 
         def request_callback(request):
-            self.assertTrue(
-                f'Content-Disposition: form-data; name="attachment"; filename="{os.path.basename(dummy_file_path)}"'
-                in request.body.decode()
-            )
+            self.assertTrue(dummy_content in request.body.decode())
             self.assertEqual(request.url, self.asset_no_extension_url_params)
-            self.assertEqual(request.headers["Content-Type"], "multipart/form-data")
+            self.assertTrue("multipart/form-data" in request.headers["Content-Type"])
             self.assertEqual("token super-token", request.headers["Authorization"])
 
             return 201, {}, json.dumps({})
@@ -759,12 +753,9 @@ class GiteaReleaseTests(TestCase):
             dummy_file.write(dummy_content)
 
         def request_callback(request):
-            self.assertTrue(
-                f'Content-Disposition: form-data; name="attachment"; filename="{os.path.basename(dummy_file_path)}"'
-                in request.body.decode()
-            )
+            self.assertTrue(dummy_content in request.body.decode())
             self.assertEqual(request.url, self.dist_asset_url_params)
-            self.assertEqual(request.headers["Content-Type"], "multipart/form-data")
+            self.assertTrue("multipart/form-data" in request.headers["Content-Type"])
             self.assertEqual("token super-token", request.headers.get("Authorization"))
 
             return 201, {}, json.dumps({})


### PR DESCRIPTION
- seems that [this](https://github.com/relekang/python-semantic-release/pull/420)  did not fix the asset uploading
- I have tested this locally so this "should" fix it