### PR TITLE
feat: add git-lfs to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # This Dockerfile is only for GitHub Actions
 FROM python:3.9
 
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git-lfs
+
 ENV PYTHONPATH /semantic-release
 
 COPY . /semantic-release


### PR DESCRIPTION
This PR adds `git-lfs` to the GitHub Actions docker container. Not really sure how I can test this, other than to say I have it working with a `git-lfs` enabled repository using my fork.

Fixes #409 