### PR TITLE
chore(dependencies): unpin tomlkit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ setup(
         "requests>=2.25,<3",
         "wheel",
         "python-gitlab>=2,<4",
+        # tomlkit used to be pinned to 0.7.0
         # See https://github.com/relekang/python-semantic-release/issues/336
         # and https://github.com/relekang/python-semantic-release/pull/337
-        # for why tomlkit is pinned
-        "tomlkit==0.7.0",
+        "tomlkit>=0.10.0,<0.11.0",
         "dotty-dict>=1.3.0,<2",
         "dataclasses==0.8; python_version < '3.7.0'",
     ],


### PR DESCRIPTION
- tests for a tomlkit regression don't fail anymore with newer tomlkit
- keep comment in setup.py about tomlkit being pinned at some point in time

refs #336