### PR TITLE
fix(prerelase): pass prerelease option to get_current_version

### DIFF
--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -98,7 +98,7 @@ def print_version(*, current=False, force_level=None, prerelease=False, **kwargs
     Print the current or new version to standard output.
     """
     try:
-        current_version = get_current_version()
+        current_version = get_current_version(prerelease)
     except GitError as e:
         print(str(e), file=sys.stderr)
         return False
@@ -130,7 +130,7 @@ def version(*, retry=False, noop=False, force_level=None, prerelease=False, **kw
 
     # Get the current version number
     try:
-        current_version = get_current_version()
+        current_version = get_current_version(prerelease)
         logger.info(f"Current version: {current_version}")
     except GitError as e:
         logger.error(str(e))
@@ -195,13 +195,13 @@ def bump_version(new_version, level_bump):
     logger.info(f"Bumping with a {level_bump} version to {new_version}")
 
 
-def changelog(*, unreleased=False, noop=False, post=False, **kwargs):
+def changelog(*, unreleased=False, noop=False, post=False, prerelease=False, **kwargs):
     """
     Generate the changelog since the last release.
 
     :raises ImproperConfigurationError: if there is no current version
     """
-    current_version = get_current_version()
+    current_version = get_current_version(prerelease)
     if current_version is None:
         raise ImproperConfigurationError(
             "Unable to get the current version. "
@@ -235,9 +235,9 @@ def changelog(*, unreleased=False, noop=False, post=False, **kwargs):
             logger.error("Missing token: cannot post changelog to HVCS")
 
 
-def publish(retry: bool = False, noop: bool = False, prerelease=False, **kwargs):
+def publish(retry: bool = False, noop: bool = False, prerelease: bool = False, **kwargs):
     """Run the version task, then push to git and upload to an artifact repository / GitHub Releases."""
-    current_version = get_current_version()
+    current_version = get_current_version(prerelease)
 
     verbose = logger.isEnabledFor(logging.DEBUG)
     if retry:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,7 +51,7 @@ def test_version_by_commit_should_call_correct_functions(mocker):
 
     version()
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -86,7 +86,7 @@ def test_version_by_tag_with_commit_version_number_should_call_correct_functions
 
     version()
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -113,7 +113,7 @@ def test_version_by_tag_should_call_correct_functions(mocker):
 
     version()
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -140,7 +140,7 @@ def test_version_by_commit_without_tag_should_call_correct_functions(mocker):
 
     version()
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -311,7 +311,7 @@ def test_print_version_no_change(mocker, runner, capsys):
     assert outerr.out == ""
     assert outerr.err == "No release will be made.\n"
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", None, False)
 
@@ -329,7 +329,7 @@ def test_print_version_change(mocker, runner, capsys):
     assert outerr.out == "1.3.0"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -346,7 +346,7 @@ def test_print_version_change_prerelease(mocker, runner, capsys):
     assert outerr.out == "1.3.0-beta.0"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once()
+    mock_current_version.assert_called_once_with(True)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -366,7 +366,7 @@ def test_print_version_change_prerelease_bump(mocker, runner, capsys):
     assert outerr.out == "1.3.0-beta.1"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once()
+    mock_current_version.assert_called_once_with(prerelease_version=True)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -383,7 +383,7 @@ def test_print_version_force_major(mocker, runner, capsys):
     assert outerr.out == "2.0.0"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", "major")
 
 
@@ -420,7 +420,7 @@ def test_version_no_change(mocker, runner):
 
     version()
 
-    mock_current_version.assert_called_once_with()
+    mock_current_version.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", None, False)
     assert not mock_set_new_version.called
@@ -525,7 +525,7 @@ def test_version_retry(mocker):
     result = version(noop=False, retry=True, force_level=False)
 
     assert result
-    mock_get_current.assert_called_once_with()
+    mock_get_current.assert_called_once_with(False)
     mock_evaluate_bump.assert_called_once_with("current", False)
     mock_get_new.assert_called_once_with("current", "patch", False)
 
@@ -820,7 +820,7 @@ def test_publish_retry_version_fail(mocker):
 
     publish(noop=False, retry=True, force_level=False)
 
-    mock_get_current.assert_called_once_with()
+    mock_get_current.assert_called_once_with(False)
     mock_get_previous.assert_called_once_with("current")
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
@@ -866,7 +866,7 @@ def test_publish_bad_token(mocker):
 
     publish(noop=False, retry=True, force_level=False)
 
-    mock_get_current.assert_called_once_with()
+    mock_get_current.assert_called_once_with(False)
     mock_get_previous.assert_called_once_with("current")
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
@@ -940,7 +940,7 @@ def test_publish_giterror_when_posting(mocker):
 
     publish(noop=False, retry=False, force_level=False)
 
-    mock_get_current.assert_called_once_with()
+    mock_get_current.assert_called_once_with(False)
     mock_evaluate.assert_called_once_with("current", False)
     mock_get_new.assert_called_once_with("current", "patch", False)
     mock_get_owner_name.assert_called_once_with()


### PR DESCRIPTION
The `get_current_version` function accepts a `prerelease` argument which was never passed.