### PR TITLE
Fix/Refactor: Prerelease 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -98,7 +98,7 @@ def print_version(*, current=False, force_level=None, prerelease=False, **kwargs
     Print the current or new version to standard output.
     """
     try:
-        current_version = get_current_version(prerelease)
+        current_version = get_current_version()
     except GitError as e:
         print(str(e), file=sys.stderr)
         return False
@@ -130,12 +130,13 @@ def version(*, retry=False, noop=False, force_level=None, prerelease=False, **kw
 
     # Get the current version number
     try:
-        current_version = get_current_version(prerelease)
+        current_version = get_current_version()
         logger.info(f"Current version: {current_version}")
     except GitError as e:
         logger.error(str(e))
         return False
     # Find what the new version number should be
+    # TODO: depending on prerelease or not we have to do this differently
     level_bump = evaluate_version_bump(current_version, force_level)
     new_version = get_new_version(current_version, level_bump, prerelease)
 
@@ -207,7 +208,7 @@ def changelog(*, unreleased=False, noop=False, post=False, prerelease=False, **k
 
     :raises ImproperConfigurationError: if there is no current version
     """
-    current_version = get_current_version(prerelease)
+    current_version = get_current_version()
     if current_version is None:
         raise ImproperConfigurationError(
             "Unable to get the current version. "
@@ -245,7 +246,7 @@ def publish(
     retry: bool = False, noop: bool = False, prerelease: bool = False, **kwargs
 ):
     """Run the version task, then push to git and upload to an artifact repository / GitHub Releases."""
-    current_version = get_current_version(prerelease)
+    current_version = get_current_version()
 
     verbose = logger.isEnabledFor(logging.DEBUG)
     if retry:

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -25,9 +25,9 @@ from .parser_tag import parse_commit_message as tag_parser  # noqa isort:skip
 logger = logging.getLogger(__name__)
 
 
-prerelease_pattern = f"-{config.get('prerelease_tag')}.\d+"
-version_pattern = f"(\d+.\d+.\d+({prerelease_pattern})?)"
-release_version_pattern = f"(\d+.\d+.\d+(?!{prerelease_pattern}))"
+prerelease_pattern = f"-{config.get('prerelease_tag')}\.\d+"
+version_pattern = f"(\d+\.\d+\.\d+({prerelease_pattern})?)"
+release_version_pattern = f"(\d+\.\d+\.\d+(?!{prerelease_pattern}))"
 
 release_version_regex = rf"{release_version_pattern}"
 version_regex = rf"{version_pattern}"

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -82,7 +82,7 @@ def get_last_version(pattern, skip_tags=None) -> Optional[str]:
 
         match = re.search(rf"{pattern}", i.name)
         if match:
-            return match.group(0).strip()  # Return only numeric vesion like 1.2.3
+            return match.group(0).strip()
 
     return None
 

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -63,7 +63,7 @@ def get_commit_log(from_rev=None):
 
 @check_repo
 @LoggedFunction(logger)
-def get_last_version(skip_tags=None, omit_pattern=None) -> Optional[str]:
+def get_last_version(pattern, skip_tags=None) -> Optional[str]:
     """
     Find the latest version using repo tags.
 
@@ -77,29 +77,13 @@ def get_last_version(skip_tags=None, omit_pattern=None) -> Optional[str]:
         return tag.commit.committed_date
 
     for i in sorted(repo.tags, reverse=True, key=version_finder):
-        match = re.search(r"\d+\.\d+\.\d+", i.name)
+        if i.name in skip_tags:
+            continue
+
+        match = re.search(rf"{pattern}", i.name)
         if match:
-            # check if the omit pattern is present in the tag (e.g. -beta for pre-release tags)
-            if omit_pattern and omit_pattern in i.name:
-                continue
-            if i.name not in skip_tags:
-                return match.group(0)  # Return only numeric vesion like 1.2.3
+            return match.group(0).strip()  # Return only numeric vesion like 1.2.3
 
-    return None
-
-
-@check_repo
-@LoggedFunction(logger)
-def get_version_from_tag(tag_name: str) -> Optional[str]:
-    """
-    Get the git commit hash corresponding to a tag name.
-
-    :param tag_name: Name of the git tag (i.e. 'v1.0.0')
-    :return: sha1 hash of the commit
-    """
-    for i in repo.tags:
-        if i.name == tag_name:
-            return i.commit.hexsha
     return None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,8 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 
+[flake8]
+max-line-length = 120
+
 [semantic_release]
 version_variable = semantic_release/__init__.py:__version__

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -144,33 +144,47 @@ class TestGetCurrentReleaseVersionByCommits:
 
 class TestGetNewVersion:
     def test_major_bump(self):
-        assert get_new_version("0.0.0", "major") == "1.0.0"
-        assert get_new_version("0.1.0", "major") == "1.0.0"
-        assert get_new_version("0.1.9", "major") == "1.0.0"
-        assert get_new_version("10.1.0", "major") == "11.0.0"
+        assert get_new_version("0.0.0", "0.0.0", "major") == "1.0.0"
+        assert get_new_version("0.1.0", "0.1.0", "major") == "1.0.0"
+        assert get_new_version("0.1.9", "0.1.9", "major") == "1.0.0"
+        assert get_new_version("10.1.0", "10.1.0", "major") == "11.0.0"
 
     def test_minor_bump(self):
-        assert type(get_new_version("0.0.0", "minor")) is str
-        assert get_new_version("0.0.0", "minor") == "0.1.0"
-        assert get_new_version("1.2.0", "minor") == "1.3.0"
-        assert get_new_version("1.2.1", "minor") == "1.3.0"
-        assert get_new_version("10.1.0", "minor") == "10.2.0"
+        assert type(get_new_version("0.0.0", "0.0.0", "minor")) is str
+        assert get_new_version("0.0.0", "0.0.0", "minor") == "0.1.0"
+        assert get_new_version("1.2.0", "1.2.0", "minor") == "1.3.0"
+        assert get_new_version("1.2.1", "1.2.1", "minor") == "1.3.0"
+        assert get_new_version("10.1.0", "10.1.0", "minor") == "10.2.0"
 
     def test_patch_bump(self):
-        assert get_new_version("0.0.0", "patch") == "0.0.1"
-        assert get_new_version("0.1.0", "patch") == "0.1.1"
-        assert get_new_version("10.0.9", "patch") == "10.0.10"
+        assert get_new_version("0.0.0", "0.0.0", "patch") == "0.0.1"
+        assert get_new_version("0.1.0", "0.1.0", "patch") == "0.1.1"
+        assert get_new_version("10.0.9", "10.0.9", "patch") == "10.0.10"
 
     def test_none_bump(self):
-        assert get_new_version("1.0.0", None) == "1.0.0"
+        assert get_new_version("1.0.0", "1.0.0", None) == "1.0.0"
 
     def test_prerelease(self):
-        assert get_new_version("1.0.0", None, True) == "1.0.1-beta.1"
-        assert get_new_version("1.0.0-beta.1", None, True) == "1.0.0-beta.2"
-        assert get_new_version("1.0.0-beta.1", "minor", True) == "1.0.0-beta.2"
-        assert get_new_version("1.0.0", "major", True) == "2.0.0-beta.1"
-        assert get_new_version("1.0.0", "minor", True) == "1.1.0-beta.1"
-        assert get_new_version("1.0.0", "patch", True) == "1.0.1-beta.1"
+        assert get_new_version("1.0.1-beta.1", "1.0.0", None, True) == "1.0.1-beta.2"
+        assert get_new_version("1.0.1-beta.1", "1.0.0", "major", True) == "2.0.0-beta.1"
+        assert get_new_version("1.0.1-beta.1", "1.0.0", "minor", True) == "1.1.0-beta.1"
+        assert get_new_version("1.0.1-beta.1", "1.0.0", "patch", True) == "1.0.1-beta.2"
+
+        assert get_new_version("1.0.0", "1.0.0", None, True) == "1.0.1-beta.1"
+        assert get_new_version("1.0.0", "1.0.0", "major", True) == "2.0.0-beta.1"
+        assert get_new_version("1.0.0", "1.0.0", "minor", True) == "1.1.0-beta.1"
+        assert get_new_version("1.0.0", "1.0.0", "patch", True) == "1.0.1-beta.1"
+
+        assert get_new_version("0.9.0-beta.1", "1.0.0", None, True) == "1.0.1-beta.1"
+        assert get_new_version("0.9.0-beta.1", "1.0.0", "major", True) == "2.0.0-beta.1"
+        assert get_new_version("0.9.0-beta.1", "1.0.0", "minor", True) == "1.1.0-beta.1"
+        assert get_new_version("0.9.0-beta.1", "1.0.0", "patch", True) == "1.0.1-beta.1"
+
+        with pytest.raises(ValueError):
+            get_new_version("0.9.0", "1.0.0", None, True)
+
+        with pytest.raises(ValueError):
+            get_new_version("1.0.0", "0.9.0", None, True)
 
 
 @mock.patch(

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -207,7 +207,7 @@ class TestVersionPattern:
             (
                 "path:__version__",
                 Path("path"),
-                r'__version__ *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']',
+                r'__version__ *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']',
             ),
         ],
     )
@@ -220,7 +220,7 @@ class TestVersionPattern:
         "str, path, pattern",
         [
             ("path:pattern", Path("path"), r"pattern"),
-            ("path:Version: {version}", Path("path"), r"Version: (\d+.\d+.\d+(-beta.\d+)?)"),
+            ("path:Version: {version}", Path("path"), r"Version: (\d+\.\d+\.\d+(-beta\.\d+)?)"),
         ],
     )
     def test_from_pattern(self, str, path, pattern):
@@ -407,7 +407,7 @@ class TestVersionPattern:
                         version_variable = "path:__version__"
                         """,
             patterns=[
-                (Path("path"), r'__version__ *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
+                (Path("path"), r'__version__ *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -416,8 +416,8 @@ class TestVersionPattern:
                         version_variable = "path1:var1,path2:var2"
                         """,
             patterns=[
-                (Path("path1"), r'var1 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
-                (Path("path2"), r'var2 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
+                (Path("path1"), r'var1 *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']'),
+                (Path("path2"), r'var2 *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -429,8 +429,8 @@ class TestVersionPattern:
                         ]
                         """,
             patterns=[
-                (Path("path1"), r'var1 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
-                (Path("path2"), r'var2 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
+                (Path("path1"), r'var1 *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']'),
+                (Path("path2"), r'var2 *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']'),
             ],
         ),
         dict(

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -95,7 +95,7 @@ class TestGetPreviousVersion:
         lambda: [("211", "0.10.0"), ("13", "0.10.0-beta"), ("13", "0.9.0")],
     )
     def test_should_return_correct_version_skip_prerelease(self):
-        assert get_previous_version("0.10.0-beta", omit_pattern="-beta") == "0.9.0"
+        assert get_previous_version("0.10.0-beta") == "0.9.0"
 
 
 class TestGetNewVersion:
@@ -121,16 +121,12 @@ class TestGetNewVersion:
         assert get_new_version("1.0.0", None) == "1.0.0"
 
     def test_prerelease(self):
-        assert get_new_version("1.0.0", None, True) == "1.0.0-beta.0"
-        assert get_new_version("1.0.0", "major", True) == "2.0.0-beta.0"
-        assert get_new_version("1.0.0", "minor", True) == "1.1.0-beta.0"
-        assert get_new_version("1.0.0", "patch", True) == "1.0.1-beta.0"
-
-    def test_prerelease_bump(self, mocker):
-        mocker.patch(
-            "semantic_release.history.get_current_version", return_value="1.0.0-beta.0"
-        )
-        assert get_new_version("1.0.0", None, True) == "1.0.0-beta.1"
+        assert get_new_version("1.0.0", None, True) == "1.0.1-beta.1"
+        assert get_new_version("1.0.0-beta.1", None, True) == "1.0.0-beta.2"
+        assert get_new_version("1.0.0-beta.1", "minor", True) == "1.0.0-beta.2"
+        assert get_new_version("1.0.0", "major", True) == "2.0.0-beta.1"
+        assert get_new_version("1.0.0", "minor", True) == "1.1.0-beta.1"
+        assert get_new_version("1.0.0", "patch", True) == "1.0.1-beta.1"
 
 
 @mock.patch(
@@ -153,7 +149,7 @@ class TestVersionPattern:
             (
                 "path:__version__",
                 Path("path"),
-                r'__version__ *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']',
+                r'__version__ *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']',
             ),
         ],
     )
@@ -166,7 +162,7 @@ class TestVersionPattern:
         "str, path, pattern",
         [
             ("path:pattern", Path("path"), r"pattern"),
-            ("path:Version: {version}", Path("path"), r"Version: (\d+\.\d+(?:\.\d+)?)"),
+            ("path:Version: {version}", Path("path"), r"Version: (\d+.\d+.\d+(-beta.\d+)?)"),
         ],
     )
     def test_from_pattern(self, str, path, pattern):
@@ -353,7 +349,7 @@ class TestVersionPattern:
                         version_variable = "path:__version__"
                         """,
             patterns=[
-                (Path("path"), r'__version__ *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path"), r'__version__ *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -362,8 +358,8 @@ class TestVersionPattern:
                         version_variable = "path1:var1,path2:var2"
                         """,
             patterns=[
-                (Path("path1"), r'var1 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
-                (Path("path2"), r'var2 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path1"), r'var1 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
+                (Path("path2"), r'var2 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
             ],
         ),
         dict(
@@ -375,8 +371,8 @@ class TestVersionPattern:
                         ]
                         """,
             patterns=[
-                (Path("path1"), r'var1 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
-                (Path("path2"), r'var2 *[:=] *["\'](\d+\.\d+(?:\.\d+)?)["\']'),
+                (Path("path1"), r'var1 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
+                (Path("path2"), r'var2 *[:=] *["\'](\d+.\d+.\d+(-beta.\d+)?)["\']'),
             ],
         ),
         dict(

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -141,6 +141,13 @@ class TestGetCurrentReleaseVersionByCommits:
     def test_should_return_correct_version_from_prerelease(self):
         assert get_current_release_version_by_commits() == "0.9.0"
 
+    @mock.patch(
+        "semantic_release.history.get_commit_log",
+        lambda: [("211", "7.28.0"), ("13", "7.27.0")],
+    )
+    def test_should_return_correct_version_without_prerelease(self):
+        assert get_current_release_version_by_commits() == "7.28.0"
+
 
 class TestGetNewVersion:
     def test_major_bump(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,12 +118,16 @@ def test_version_by_tag_only_with_commit_version_number_should_call_correct_func
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once_with()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", "major", False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", "major", False)
     assert not mock_set_new_version.called
     assert not mock_commit_new_version.called
     mock_tag_new_version.assert_called_once_with("2.0.0")
@@ -171,12 +175,16 @@ def test_version_by_tag_only_should_call_correct_functions(mocker):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once_with()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", "major", False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", "major", False)
     assert not mock_set_new_version.called
     mock_tag_new_version.assert_called_once_with("2.0.0")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,7 +51,7 @@ def test_version_by_commit_should_call_correct_functions(mocker):
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -86,7 +86,7 @@ def test_version_by_tag_with_commit_version_number_should_call_correct_functions
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -148,7 +148,7 @@ def test_version_by_tag_should_call_correct_functions(mocker):
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -201,7 +201,7 @@ def test_version_by_commit_without_tag_should_call_correct_functions(mocker):
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
@@ -372,7 +372,7 @@ def test_print_version_no_change(mocker, runner, capsys):
     assert outerr.out == ""
     assert outerr.err == "No release will be made.\n"
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", None, False)
 
@@ -390,7 +390,7 @@ def test_print_version_change(mocker, runner, capsys):
     assert outerr.out == "1.3.0"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -404,10 +404,10 @@ def test_print_version_change_prerelease(mocker, runner, capsys):
 
     print_version(prerelease=True)
     outerr = capsys.readouterr()
-    assert outerr.out == "1.3.0-beta.0"
+    assert outerr.out == "1.3.0-beta.1"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once_with(True)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -427,7 +427,6 @@ def test_print_version_change_prerelease_bump(mocker, runner, capsys):
     assert outerr.out == "1.3.0-beta.1"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once_with(prerelease_version=True)
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -444,7 +443,7 @@ def test_print_version_force_major(mocker, runner, capsys):
     assert outerr.out == "2.0.0"
     assert outerr.err == ""
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", "major")
 
 
@@ -458,7 +457,7 @@ def test_print_version_force_major_prerelease(mocker, runner, capsys):
 
     print_version(force_level="major", prerelease=True)
     outerr = capsys.readouterr()
-    assert outerr.out == "2.0.0-beta.0"
+    assert outerr.out == "2.0.0-beta.1"
     assert outerr.err == ""
 
     mock_current_version.assert_called_once()
@@ -481,7 +480,7 @@ def test_version_no_change(mocker, runner):
 
     version()
 
-    mock_current_version.assert_called_once_with(False)
+    mock_current_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
     mock_new_version.assert_called_once_with("1.2.3", None, False)
     assert not mock_set_new_version.called
@@ -609,7 +608,7 @@ def test_version_retry(mocker):
     result = version(noop=False, retry=True, force_level=False)
 
     assert result
-    mock_get_current.assert_called_once_with(False)
+    mock_get_current.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("current", False)
     mock_get_new.assert_called_once_with("current", "patch", False)
 
@@ -904,7 +903,7 @@ def test_publish_retry_version_fail(mocker):
 
     publish(noop=False, retry=True, force_level=False)
 
-    mock_get_current.assert_called_once_with(False)
+    mock_get_current.assert_called_once()
     mock_get_previous.assert_called_once_with("current")
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
@@ -950,7 +949,7 @@ def test_publish_bad_token(mocker):
 
     publish(noop=False, retry=True, force_level=False)
 
-    mock_get_current.assert_called_once_with(False)
+    mock_get_current.assert_called_once()
     mock_get_previous.assert_called_once_with("current")
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
@@ -1024,7 +1023,7 @@ def test_publish_giterror_when_posting(mocker):
 
     publish(noop=False, retry=False, force_level=False)
 
-    mock_get_current.assert_called_once_with(False)
+    mock_get_current.assert_called_once()
     mock_evaluate.assert_called_once_with("current", False)
     mock_get_new.assert_called_once_with("current", "patch", False)
     mock_get_owner_name.assert_called_once_with()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,12 +48,16 @@ def test_version_by_commit_should_call_correct_functions(mocker):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", "major", False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_commit_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
@@ -83,12 +87,16 @@ def test_version_by_tag_with_commit_version_number_should_call_correct_functions
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", "major", False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_commit_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
@@ -149,12 +157,16 @@ def test_version_by_tag_should_call_correct_functions(mocker):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", "major", False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_tag_new_version.assert_called_once_with("2.0.0")
 
@@ -206,12 +218,16 @@ def test_version_by_commit_without_tag_should_call_correct_functions(mocker):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", "major", False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", "major", False)
     mock_set_new_version.assert_called_once_with("2.0.0")
     mock_commit_new_version.assert_called_once_with("2.0.0")
     assert not mock_tag_new_version.called
@@ -374,6 +390,9 @@ def test_print_version_no_change(mocker, runner, capsys):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     print_version()
     outerr = capsys.readouterr()
@@ -381,13 +400,17 @@ def test_print_version_no_change(mocker, runner, capsys):
     assert outerr.err == "No release will be made.\n"
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", None, False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", None, False)
 
 
 def test_print_version_change(mocker, runner, capsys):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate_bump = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="minor"
@@ -399,12 +422,16 @@ def test_print_version_change(mocker, runner, capsys):
     assert outerr.err == ""
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
 def test_print_version_change_prerelease(mocker, runner, capsys):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate_bump = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="minor"
@@ -416,6 +443,7 @@ def test_print_version_change_prerelease(mocker, runner, capsys):
     assert outerr.err == ""
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
@@ -423,8 +451,8 @@ def test_print_version_change_prerelease_bump(mocker, runner, capsys):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
-    mock_current_version = mocker.patch(
-        "semantic_release.history.get_current_version", return_value="1.3.0-beta.0"
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate_bump = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="minor"
@@ -435,12 +463,17 @@ def test_print_version_change_prerelease_bump(mocker, runner, capsys):
     assert outerr.out == "1.3.0-beta.1"
     assert outerr.err == ""
 
+    mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
 
 
 def test_print_version_force_major(mocker, runner, capsys):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate_bump = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="major"
@@ -452,12 +485,16 @@ def test_print_version_force_major(mocker, runner, capsys):
     assert outerr.err == ""
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", "major")
 
 
 def test_print_version_force_major_prerelease(mocker, runner, capsys):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate_bump = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="major"
@@ -469,6 +506,7 @@ def test_print_version_force_major_prerelease(mocker, runner, capsys):
     assert outerr.err == ""
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", "major")
 
 
@@ -485,12 +523,16 @@ def test_version_no_change(mocker, runner):
     mock_current_version = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="1.2.3"
     )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
 
     version()
 
     mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
     mock_evaluate_bump.assert_called_once_with("1.2.3", None)
-    mock_new_version.assert_called_once_with("1.2.3", None, False)
+    mock_new_version.assert_called_once_with("1.2.3", "1.2.3", None, False)
     assert not mock_set_new_version.called
     assert not mock_commit_new_version.called
     assert not mock_tag_new_version.called
@@ -602,8 +644,11 @@ def test_version_retry_and_giterror(mocker):
 
 
 def test_version_retry(mocker):
-    mock_get_current = mocker.patch(
-        "semantic_release.cli.get_current_version", return_value="current"
+    mock_current_version = mocker.patch(
+        "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate_bump = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="patch"
@@ -616,9 +661,10 @@ def test_version_retry(mocker):
     result = version(noop=False, retry=True, force_level=False)
 
     assert result
-    mock_get_current.assert_called_once()
-    mock_evaluate_bump.assert_called_once_with("current", False)
-    mock_get_new.assert_called_once_with("current", "patch", False)
+    mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
+    mock_evaluate_bump.assert_called_once_with("1.2.3", False)
+    mock_get_new.assert_called_once_with("1.2.3", "1.2.3", "patch", False)
 
 
 def test_publish_should_not_run_pre_commit_by_default(mocker):
@@ -895,8 +941,11 @@ def test_publish_retry_version_fail(mocker):
     mock_get_current = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="current"
     )
-    mock_get_previous = mocker.patch(
-        "semantic_release.cli.get_previous_version", return_value="previous"
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
+    get_previous_release_version = mocker.patch(
+        "semantic_release.cli.get_previous_release_version", return_value="previous"
     )
     mock_get_owner_name = mocker.patch(
         "semantic_release.cli.get_repository_owner_and_name",
@@ -912,7 +961,8 @@ def test_publish_retry_version_fail(mocker):
     publish(noop=False, retry=True, force_level=False)
 
     mock_get_current.assert_called_once()
-    mock_get_previous.assert_called_once_with("current")
+    mock_current_release_version.assert_called_once()
+    get_previous_release_version.assert_called_once_with("current")
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
     mock_checkout.assert_called_once_with("my_branch")
@@ -925,8 +975,11 @@ def test_publish_bad_token(mocker):
     mock_get_current = mocker.patch(
         "semantic_release.cli.get_current_version", return_value="current"
     )
-    mock_get_previous = mocker.patch(
-        "semantic_release.cli.get_previous_version", return_value="previous"
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
+    )
+    get_previous_release_version = mocker.patch(
+        "semantic_release.cli.get_previous_release_version", return_value="previous"
     )
     mock_get_owner_name = mocker.patch(
         "semantic_release.cli.get_repository_owner_and_name",
@@ -958,7 +1011,8 @@ def test_publish_bad_token(mocker):
     publish(noop=False, retry=True, force_level=False)
 
     mock_get_current.assert_called_once()
-    mock_get_previous.assert_called_once_with("current")
+    mock_current_release_version.assert_called_once()
+    get_previous_release_version.assert_called_once_with("current")
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
     mock_checkout.assert_called_once_with("my_branch")
@@ -978,8 +1032,11 @@ def test_publish_bad_token(mocker):
 
 
 def test_publish_giterror_when_posting(mocker):
-    mock_get_current = mocker.patch(
-        "semantic_release.cli.get_current_version", return_value="current"
+    mock_current_version = mocker.patch(
+        "semantic_release.cli.get_current_version", return_value="1.2.3"
+    )
+    mock_current_release_version = mocker.patch(
+        "semantic_release.cli.get_current_release_version", return_value="1.2.3"
     )
     mock_evaluate = mocker.patch(
         "semantic_release.cli.evaluate_version_bump", return_value="patch"
@@ -1031,14 +1088,15 @@ def test_publish_giterror_when_posting(mocker):
 
     publish(noop=False, retry=False, force_level=False)
 
-    mock_get_current.assert_called_once()
-    mock_evaluate.assert_called_once_with("current", False)
-    mock_get_new.assert_called_once_with("current", "patch", False)
+    mock_current_version.assert_called_once()
+    mock_current_release_version.assert_called_once()
+    mock_evaluate.assert_called_once_with("1.2.3", False)
+    mock_get_new.assert_called_once_with("1.2.3", "1.2.3", "patch", False)
     mock_get_owner_name.assert_called_once_with()
     mock_ci_check.assert_called()
     mock_checkout.assert_called_once_with("my_branch")
     mock_should_bump_version.assert_called_once_with(
-        current_version="current", new_version="new", noop=False, retry=False
+        current_version="1.2.3", new_version="new", noop=False, retry=False
     )
     mock_update_changelog_file.assert_called_once_with("new", "super md changelog")
     mock_bump_version.assert_called_once_with("new", "patch")
@@ -1052,14 +1110,14 @@ def test_publish_giterror_when_posting(mocker):
         domain="domain",
     )
     mock_check_token.assert_called_once_with()
-    mock_generate.assert_called_once_with("current")
+    mock_generate.assert_called_once_with("1.2.3")
     mock_markdown.assert_called_once_with(
         "owner",
         "name",
         "new",
         "super changelog",
         header=False,
-        previous_version="current",
+        previous_version="1.2.3",
     )
     mock_post.assert_called_once_with("owner", "name", "new", "super md changelog")
 

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -6,7 +6,7 @@ import pytest
 from git import GitCommandError, Repo, TagObject
 
 from semantic_release.errors import GitError, HvcsRepoParseError
-from semantic_release.history import version_pattern
+from semantic_release.history import version_pattern, release_version_pattern
 from semantic_release.vcs_helpers import (
     check_repo,
     checkout,
@@ -354,6 +354,9 @@ def test_get_last_version(pattern, skip_tags, expected_result):
         (version_pattern, ["v2.1.0-beta.0"], "2.0.0"),
         (version_pattern, ["v2.1.0-beta.0", "v2.0.0-beta.0", "v2.0.0"], "1.1.0"),
         (version_pattern, ["v2.1.0-beta.0", "v2.0.0-beta.0", "v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"], None),
+        (release_version_pattern, None, "2.0.0"),
+        (release_version_pattern, ["v2.0.0"], "1.1.0"),
+        (release_version_pattern, ["v2.0.0", "v1.1.0", "v1.0.0", "v0.1.0"], None),
     ],
 )
 def test_get_last_version_with_real_pattern(pattern, skip_tags, expected_result):


### PR DESCRIPTION
## Ready for review

Related to https://github.com/relekang/python-semantic-release/issues/434

When digging into the issue I encountered some more misalignments in my previous provided code for the prerelease feature.
With this PR I want to fix this issues and also do some normalisation work in the package.

@danth @williamluke4 @relekang 
~~Curiously, locally all tests pass. I checked and the test fail because of methods which traverse the git log... 
Locally all commits starting from the current branch are analysed (ending with the init commit) - but in the ci pipeline, there is only one commit (Some merge commit I can't find nowhere else... ). Any Idea why this is happening and how to prevent it?~~
Solved: The problem was, that by default githubs `actions/checkout@v2` checks out a single merge commit. It has to be instructed to checkout the actual brach with its full history.

**Main changes:**

* The way new versions are determined now utilise the semvar package
* normalised the way versions are matched via regex
* Better and unified way to get the current release version

**Unsolved Issues:**

* The whole flow only works, if the same branch is issued for all releases and version bumps (possible improvement: https://github.com/relekang/python-semantic-release/issues/423). To make it work on different branches we need to change how tags are analysed (just in the current branch history)

**Possible improvements:**
There are now two similar methods to get the current version: 
`get_current_version`: gets the _last_ version, whatever is the last tag or in the config file
`get_current_release_version`: gets the _last not-prerelease_ version (this is needed to determine the correct level_bump)
for ease of use (they are mostly used together) and further development, this two methods could be merged and return a tuple `(current_version, current_release_version)`