### PR TITLE
fix: version_source=tag_only current version should ignore config file

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -228,7 +228,7 @@ def get_current_version(prerelease_version: bool = False) -> str:
     :return: A string with the current version number
     """
     omit_pattern = None if prerelease_version else get_prerelease_pattern()
-    if config.get("version_source") == "tag":
+    if config.get("version_source") in ["tag", "tag_only"]:
         return get_current_version_by_tag(omit_pattern)
     current_version = get_current_version_by_config_file(omit_pattern)
     if omit_pattern and omit_pattern in current_version:

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -50,6 +50,19 @@ def test_current_version_should_return_default_version(mock_last_version):
     assert "0.0.0" == get_current_version()
 
 
+@mock.patch(
+    "semantic_release.history.config.get", wrapped_config_get(version_source="tag_only")
+)
+def test_current_version_should_run_with_tag_only(mocker):
+    mock_get_current_version_by_tag = mocker.patch(
+        "semantic_release.history.get_current_version_by_tag", return_value=None
+    )
+
+    get_current_version()
+
+    assert mock_get_current_version_by_tag.called
+
+
 class TestGetPreviousVersion:
     @mock.patch(
         "semantic_release.history.get_commit_log",

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -16,6 +16,7 @@ from semantic_release.history import (
     get_previous_version,
     load_version_declarations,
     set_new_version,
+    get_current_version_by_config_file,
 )
 
 from .. import wrapped_config_get
@@ -57,10 +58,14 @@ def test_current_version_should_run_with_tag_only(mocker):
     mock_get_current_version_by_tag = mocker.patch(
         "semantic_release.history.get_current_version_by_tag", return_value=None
     )
+    mock_get_current_version_by_config_file = mocker.patch(
+        "semantic_release.history.get_current_version_by_config_file", return_value=None
+    )
 
     get_current_version()
 
     assert mock_get_current_version_by_tag.called
+    assert not mock_get_current_version_by_config_file.called
 
 
 class TestGetPreviousVersion:


### PR DESCRIPTION
Related to https://github.com/relekang/python-semantic-release/issues/354

## Issue

Version `7.28.0` introduced new `version_source=tag_only` functionality. However, `publish`, `version` and `print_version` rely on [get_current_version function](https://github.com/relekang/python-semantic-release/blob/7bffd66a84111efc31f1e4379466b5edcb461133/semantic_release/history/__init__.py#L223), which doesn't implement the new functionality.

## Repro

```bash
$ pip show python-semantic-release 
Name: python-semantic-release
Version: 7.28.0
Summary: Automatic Semantic Versioning for Python projects
Home-page: http://github.com/relekang/python-semantic-release
Author: Rolf Erik Lekang
Author-email: me@rolflekang.com
License: MIT
Location: /Users/raf/virtualenvs/index-service/lib/python3.9/site-packages
Requires: click, click-log, dotty-dict, gitpython, invoke, python-gitlab, requests, semver, tomlkit, twine, wheel
Required-by: 
$ semantic-release print-version --current --define=version_source=tag_only
must specify either 'version_variable', 'version_pattern' or 'version_toml'
```
