### PR TITLE
fix: get_current_release_version incorrectly parses commit message with version

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -324,7 +324,7 @@ def get_previous_version(version: str) -> Optional[str]:
     :return: A string with the previous version number.
     """
     found_version = False
-    for commit_hash, commit_message in get_commit_log():
+    for commit_hash, commit_message, _ in get_commit_log():
         logger.debug(f"Checking commit {commit_hash}")
         if version in commit_message:
             found_version = True
@@ -349,7 +349,7 @@ def get_previous_release_version(version: str) -> Optional[str]:
     :return: A string with the previous version number.
     """
     found_version = False
-    for commit_hash, commit_message in get_commit_log():
+    for commit_hash, commit_message, _ in get_commit_log():
         logger.debug(f"Checking commit {commit_hash}")
         if version in commit_message:
             found_version = True
@@ -372,10 +372,10 @@ def get_current_release_version_by_commits() -> str:
 
     :return: A string with the current version number.
     """
-    for commit_hash, commit_message in get_commit_log():
+    for commit_hash, commit_message, commit_author in get_commit_log():
         logger.debug(f"Checking commit {commit_hash}")
         match = re.search(rf"{release_version_pattern}", commit_message)
-        if match:
+        if match and commit_author.name == "github-actions" and commit_author.email == "action@github.com":
             logger.debug(f"Version matches regex {commit_message}")
             return match.group(1).strip()
 

--- a/semantic_release/history/logs.py
+++ b/semantic_release/history/logs.py
@@ -36,7 +36,7 @@ def evaluate_version_bump(current_version: str, force: str = None) -> Optional[s
     changes = []
     commit_count = 0
 
-    for _hash, commit_message in get_commit_log(current_version):
+    for _hash, commit_message, _ in get_commit_log(current_version):
         if commit_message.startswith(current_version):
             # Stop once we reach the current version
             # (we are looping in the order of newest -> oldest)
@@ -98,7 +98,7 @@ def generate_changelog(from_version: str, to_version: str = None) -> dict:
         rev = from_version
 
     found_the_release = to_version is None
-    for _hash, commit_message in get_commit_log(rev):
+    for _hash, commit_message, _ in get_commit_log(rev):
         if not found_the_release:
             # Skip until we find the last commit in this release
             # (we are looping in the order of newest -> oldest)

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -3,7 +3,7 @@
 import logging
 import mimetypes
 import os
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 from urllib.parse import urlsplit
 
 from gitlab import exceptions, gitlab
@@ -578,7 +578,7 @@ class Gitea(Base):
                 url,
                 params={"name": name},
                 data={},
-                files=[
+                files=[  # type: ignore
                     (
                         "attachment",
                         (

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -58,7 +58,7 @@ def get_commit_log(from_rev=None):
             )
 
     for commit in repo.iter_commits(rev):
-        yield (commit.hexsha, commit.message.replace("\r\n", "\n"))
+        yield (commit.hexsha, commit.message.replace("\r\n", "\n"), commit.author)
 
 
 @check_repo

--- a/tests/history/__init__.py
+++ b/tests/history/__init__.py
@@ -2,16 +2,19 @@ MAJOR = (
     "221",
     "feat(x): Add super-feature\n\n"
     "BREAKING CHANGE: Uses super-feature as default instead of dull-feature.",
+    "Alice <alice@example.com>",
 )
 MAJOR2 = (
     "222",
     "feat(x): Add super-feature\n\nSome explanation\n\n"
     "BREAKING CHANGE: Uses super-feature as default instead of dull-feature.",
+    "Alice <alice@example.com>",
 )
 MAJOR_MENTIONING_1_0_0 = (
     "223",
     "feat(x): Add super-feature\n\nSome explanation\n\n"
     "BREAKING CHANGE: Uses super-feature as default instead of dull-feature from v1.0.0.",
+    "Alice <alice@example.com>",
 )
 MAJOR_MULTIPLE_FOOTERS = (
     "244",
@@ -19,23 +22,26 @@ MAJOR_MULTIPLE_FOOTERS = (
     "BREAKING CHANGE: Breaking change 1\n\n"
     "Not a BREAKING CHANGE\n\n"
     "BREAKING CHANGE: Breaking change 2",
+    "Alice <alice@example.com>",
 )
 MAJOR_EXCL_WITH_FOOTER = (
     "231",
     "feat(x)!: Add another feature\n\n"
     "BREAKING CHANGE: Another feature, another breaking change",
+    "Alice <alice@example.com>",
 )
 MAJOR_EXCL_NOT_FOOTER = (
     "232",
     "fix!: Fix a big bug that everyone exploited\n\nThis is the reason you should not exploit bugs",
+    "Alice <alice@example.com>",
 )
-MINOR = ("111", "feat(x): Add non-breaking super-feature")
-PATCH = ("24", "fix(x): Fix bug in super-feature")
-NO_TAG = ("191", "docs(x): Add documentation for super-feature")
-UNKNOWN_STYLE = ("7", "random commits are the worst")
+MINOR = ("111", "feat(x): Add non-breaking super-feature", "Bob <bob@example.com>")
+PATCH = ("24", "fix(x): Fix bug in super-feature", "Bob <bob@example.com>")
+NO_TAG = ("191", "docs(x): Add documentation for super-feature", "John <john@example.com>")
+UNKNOWN_STYLE = ("7", "random commits are the worst", "John <john@example.com>")
 
 ALL_KINDS_OF_COMMIT_MESSAGES = [MINOR, MAJOR, MINOR, PATCH]
 MINOR_AND_PATCH_COMMIT_MESSAGES = [MINOR, PATCH]
 PATCH_COMMIT_MESSAGES = [PATCH, PATCH]
-MAJOR_LAST_RELEASE_MINOR_AFTER = [MINOR, ("22", "1.1.0"), MAJOR]
-MAJOR_MENTIONING_LAST_VERSION = [MAJOR_MENTIONING_1_0_0, ("22", "1.0.0"), MAJOR]
+MAJOR_LAST_RELEASE_MINOR_AFTER = [MINOR, ("22", "1.1.0", "Doe <doe@example.com>"), MAJOR]
+MAJOR_MENTIONING_LAST_VERSION = [MAJOR_MENTIONING_1_0_0, ("22", "1.0.0", "Doe <doe@example.com>"), MAJOR]

--- a/tests/history/test_changelog.py
+++ b/tests/history/test_changelog.py
@@ -94,7 +94,7 @@ def test_scope_is_included_in_changelog(commit, commit_type, expected):
 
 @mock.patch(
     "semantic_release.history.logs.get_commit_log",
-    lambda *a, **k: [("24", "fix: Fix another bug")],
+    lambda *a, **k: [("24", "fix: Fix another bug", "Alice <alice@example.com>")],
 )
 def test_scope_is_omitted_with_empty_scope():
     changelog = generate_changelog("0.0.0")
@@ -123,15 +123,16 @@ def test_scope_included_in_changelog_configurable(commit, commit_type):
 
 @mock.patch(
     "semantic_release.history.logs.get_commit_log",
-    lambda *a, **k: [("23", "fix(x): abCD"), ("23", "fix: abCD")],
+    lambda *a, **k: [("23", "fix(x): abCD", "Alice <alice@example.com>"),
+                     ("23", "fix: abCD", "Alice <alice@example.com>")],
 )
 @pytest.mark.parametrize(
     "commit,config_setting,expected_description",
     [
-        (("23", "fix(x): abCD"), True, "**x:** AbCD"),
-        (("23", "fix(x): abCD"), False, "**x:** abCD"),
-        (("23", "fix: abCD"), True, "AbCD"),
-        (("23", "fix: abCD"), False, "abCD"),
+        (("23", "fix(x): abCD", "Alice <alice@example.com>"), True, "**x:** AbCD"),
+        (("23", "fix(x): abCD", "Alice <alice@example.com>"), False, "**x:** abCD"),
+        (("23", "fix: abCD", "Alice <alice@example.com>"), True, "AbCD"),
+        (("23", "fix: abCD", "Alice <alice@example.com>"), False, "abCD"),
     ],
 )
 def test_message_capitalization_is_configurable(

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import mock
 import pytest
+from git.util import Actor
 
 import semantic_release
 from semantic_release.history import (
@@ -92,28 +93,33 @@ def test_current_release_version_should_return_default_version(
 class TestGetPreviousVersion:
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version(self):
         assert get_previous_version("0.10.0") == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "v0.10.0"), ("13", "v0.9.0")],
+        lambda: [("211", "v0.10.0", Actor("github-actions", "action@github.com")),
+                 ("13", "v0.9.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version_with_v(self):
         assert get_previous_version("0.10.0") == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0-beta"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0-beta", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version_from_prerelease(self):
         assert get_previous_version("0.10.0-beta") == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0"), ("13", "0.10.0-beta"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0",  Actor("github-actions", "action@github.com")),
+                 ("13", "0.10.0-beta", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.0",  Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version_skip_prerelease(self):
         assert get_previous_version("0.10.0-beta") == "0.9.0"
@@ -122,28 +128,34 @@ class TestGetPreviousVersion:
 class TestGetCurrentReleaseVersionByCommits:
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0-beta.1"), ("13", "0.9.1-beta.1"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0-beta.1", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.1-beta.1", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version(self):
         assert get_current_release_version_by_commits() == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "v0.10.0-beta.1"), ("13", "0.9.1-beta.1"), ("13", "v0.9.0")],
+        lambda: [("211", "v0.10.0-beta.1", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.1-beta.1", Actor("github-actions", "action@github.com")),
+                 ("13", "v0.9.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version_with_v(self):
         assert get_current_release_version_by_commits() == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0-beta.0"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0-beta.0", Actor("github-actions", "action@github.com")),
+                 ("13", "0.9.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version_from_prerelease(self):
         assert get_current_release_version_by_commits() == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "7.28.0"), ("13", "7.27.0")],
+        lambda: [("211", "7.28.0", Actor("github-actions", "action@github.com")),
+                 ("13", "7.27.0", Actor("github-actions", "action@github.com"))],
     )
     def test_should_return_correct_version_without_prerelease(self):
         assert get_current_release_version_by_commits() == "7.28.0"

--- a/tests/history/test_version_bump.py
+++ b/tests/history/test_version_bump.py
@@ -33,7 +33,7 @@ def test_patch():
 def test_nothing_if_no_tag():
     with mock.patch(
         "semantic_release.history.logs.get_commit_log",
-        lambda *a, **kw: [("", "...")],
+        lambda *a, **kw: [("", "...", "")],
     ):
         assert evaluate_version_bump("0.0.0") is None
 


### PR DESCRIPTION
**Context:**
- Related to https://github.com/relekang/python-semantic-release/issues/442
- The most recent PR that was merged https://github.com/relekang/python-semantic-release/pull/435 seems to be causing this issue
- From my observation and tests, `get_current_release_version_by_commits` seems to be parsing version incorrectly from commit messages
- For example, this issue occurs when the commit messages that contain versioning are parsed, e.g. "fix(deps): update dependency pylint to 2.13.8" -> `2.13.8`
- More examples [here](https://pythex.org/?regex=(%5Cd%2B%5C.%5Cd%2B%5C.%5Cd%2B(%3F!-beta%5C.%5Cd%2B))&test_string=chore(deps)%3A%20update%20dependency%20pylint%20to%20v2.13.8%0Afix(deps)%3A%20update%20dependency%20sqlalchemy%20to%201.4.36%0A20.10.199111%0A1.4.1%0Av1.4.2%0A0.3.5-beta.0%0A1.41.4%0Atry%20to%20update%201.6.7%20to%201.61.1%20later&ignorecase=0&multiline=1&dotall=0&verbose=0)

**Main changes:**
- `get_commit_log` now yields an additional `commit.author` info to the returned tuple
- `get_current_release_version_by_commits` now checks that `commit_author.name == "github-actions" and commit_author.email == "action@github.com"` before returning version that matches regex in the commit message

**Description:**
- The main idea behind this change is that there is not really a guaranteed way for us to parse versions correctly from users' commit messages as users can write commit messages however they want
- This fix checks for the commit author to cope with the issue above

**How has this been tested:**
- Ran `tox` locally and passes all test cases
- Tried running `../python-semantic-release/semantic_release/.venv/bin/python -m semantic_release publish -v DEBUG --noop` locally on one of my repository that uses and failed `python-semantic-release` action recently

Let me know if this works! I'm more than happy to work together to fix this!