### PR TITLE
chore: fix test and doc failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ target/
 
 .pytest_cache
 .mypy_cache
+.python-version

--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -578,16 +578,13 @@ class Gitea(Base):
                 url,
                 params={"name": name},
                 data={},
-                files=[
-                    (
-                        "attachment",
-                        (
-                            name,
-                            open(file, "rb"),
-                            "application/octet-stream",
-                        ),
-                    )
-                ],
+                files={
+                    "attachment": (
+                        name,
+                        open(file, "rb"),
+                        "application/octet-stream",
+                    ),
+                },
             )
 
             logger.debug(

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
             "responses==0.13.3",
             "mock==1.3.0",
         ],
-        "docs": ["Sphinx==1.3.6"],
+        "docs": ["Sphinx==1.3.6", "Jinja2==3.0.3"],
         "dev": ["tox", "isort", "black"],
         "mypy": ["mypy", "types-requests"],
     },


### PR DESCRIPTION
## Fix `tox -emypy` failure
.. would fail with
```
semantic_release/hvcs.py:581: error: Argument "files" to "post" of "Session" has incompatible type "List[Tuple[str, Tuple[str, BufferedReader, str]]]"; expected "Optional[Union[Mapping[str, Union[SupportsRead[Union[str, bytes]], str, bytes]], Mapping[str, Tuple[Optional[str], Union[SupportsRead[Union[str, bytes]], str, bytes]]], Mapping[str, Tuple[Optional[str], Union[SupportsRead[Union[str, bytes]], str, bytes], str]], Mapping[str, Tuple[Optional[str], Union[SupportsRead[Union[str, bytes]], str, bytes], str, MutableMapping[str, str]]]]]"
Found 1 error in 1 file (checked 22 source files)
ERROR: InvocationError for command /Users/briancho/src/oss/python-semantic-release/.tox/mypy/bin/mypy --ignore-missing-imports semantic_release (exited with code 1)
____________________________________________________________ summary _____________________________________________________________
ERROR:   mypy: commands failed
```

## Fix `pip install -e ".[docs]"; (cd docs; make html)`
.. would fail with
```
Exception occurred:
  File "/Users/briancho/src/oss/python-semantic-release/venv/lib/python3.9/site-packages/sphinx/jinja2glue.py", line 16, in <module>
    from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
ImportError: cannot import name 'contextfunction' from 'jinja2' (/Users/briancho/src/oss/python-semantic-release/venv/lib/python3.9/site-packages/jinja2/__init__.py)
```