### PR TITLE
fix ci tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/semantic_release/cli.py
+++ b/semantic_release/cli.py
@@ -15,11 +15,11 @@ from .changelog import markdown_changelog
 from .dist import build_dists, remove_dists, should_build, should_remove_dist
 from .history import (
     evaluate_version_bump,
-    get_current_version,
     get_current_release_version,
+    get_current_version,
     get_new_version,
-    get_previous_version,
     get_previous_release_version,
+    get_previous_version,
     set_new_version,
 )
 from .history.logs import generate_changelog
@@ -102,7 +102,9 @@ def print_version(*, current=False, force_level=None, prerelease=False, **kwargs
     try:
         current_version = get_current_version()
         current_release_version = get_current_release_version()
-        logger.info(f"Current version: {current_version}, Current release version: {current_release_version}")
+        logger.info(
+            f"Current version: {current_version}, Current release version: {current_release_version}"
+        )
     except GitError as e:
         print(str(e), file=sys.stderr)
         return False
@@ -112,7 +114,9 @@ def print_version(*, current=False, force_level=None, prerelease=False, **kwargs
 
     # Find what the new version number should be
     level_bump = evaluate_version_bump(current_version, force_level)
-    new_version = get_new_version(current_version, current_release_version, level_bump, prerelease)
+    new_version = get_new_version(
+        current_version, current_release_version, level_bump, prerelease
+    )
     if should_bump_version(current_version=current_version, new_version=new_version):
         print(new_version, end="")
         return True
@@ -136,13 +140,17 @@ def version(*, retry=False, noop=False, force_level=None, prerelease=False, **kw
     try:
         current_version = get_current_version()
         current_release_version = get_current_release_version()
-        logger.info(f"Current version: {current_version}, Current release version: {current_release_version}")
+        logger.info(
+            f"Current version: {current_version}, Current release version: {current_release_version}"
+        )
     except GitError as e:
         logger.error(str(e))
         return False
     # Find what the new version number should be
     level_bump = evaluate_version_bump(current_release_version, force_level)
-    new_version = get_new_version(current_version, current_release_version, level_bump, prerelease)
+    new_version = get_new_version(
+        current_version, current_release_version, level_bump, prerelease
+    )
 
     if not should_bump_version(
         current_version=current_version, new_version=new_version, retry=retry, noop=noop
@@ -252,7 +260,9 @@ def publish(
     """Run the version task, then push to git and upload to an artifact repository / GitHub Releases."""
     current_version = get_current_version()
     current_release_version = get_current_release_version()
-    logger.info(f"Current version: {current_version}, Current release version: {current_release_version}")
+    logger.info(
+        f"Current version: {current_version}, Current release version: {current_release_version}"
+    )
 
     verbose = logger.isEnabledFor(logging.DEBUG)
     if retry:
@@ -265,7 +275,9 @@ def publish(
     else:
         # Calculate the new version
         level_bump = evaluate_version_bump(current_version, kwargs.get("force_level"))
-        new_version = get_new_version(current_version, current_release_version, level_bump, prerelease)
+        new_version = get_new_version(
+            current_version, current_release_version, level_bump, prerelease
+        )
 
     owner, name = get_repository_owner_and_name()
 

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -53,9 +53,7 @@ class VersionDeclaration(ABC):
         variable name.
         """
         path, variable = config_str.split(":", 1)
-        pattern = (
-            rf'{variable} *[:=] *["\']{version_regex}["\']'
-        )
+        pattern = rf'{variable} *[:=] *["\']{version_regex}["\']'
         return PatternVersionDeclaration(path, pattern)
 
     @staticmethod
@@ -266,7 +264,10 @@ def get_current_release_version() -> str:
 
 @LoggedFunction(logger)
 def get_new_version(
-    current_version: str, current_release_version: str, level_bump: str, prerelease: bool = False
+    current_version: str,
+    current_release_version: str,
+    level_bump: str,
+    prerelease: bool = False,
 ) -> str:
     """
     Calculate the next version based on the given bump level with semver.
@@ -285,7 +286,10 @@ def get_new_version(
     # sanity check
     # if the current version is no prerelease, than
     # current_version and current_release_version must be the same
-    if not current_version_info.prerelease and current_version_info.compare(current_release_version_info) != 0:
+    if (
+        not current_version_info.prerelease
+        and current_version_info.compare(current_release_version_info) != 0
+    ):
         raise ValueError()
 
     if level_bump:
@@ -303,11 +307,15 @@ def get_new_version(
         if current_version_info.prerelease and next_raw_version == current_raw_version:
             # next version (based on commits) matches current prerelease version
             # bump prerelase
-            next_prerelease_version_info = current_version_info.bump_prerelease(config.get("prerelease_tag"))
+            next_prerelease_version_info = current_version_info.bump_prerelease(
+                config.get("prerelease_tag")
+            )
         else:
             # next version (based on commits) higher than current prerelease version
             # new prerelease based on next version
-            next_prerelease_version_info = next_version_info.bump_prerelease(config.get("prerelease_tag"))
+            next_prerelease_version_info = next_version_info.bump_prerelease(
+                config.get("prerelease_tag")
+            )
 
         return str(next_prerelease_version_info)
     else:
@@ -337,7 +345,9 @@ def get_previous_version(version: str) -> Optional[str]:
                 logger.debug(f"Version matches regex {commit_message}")
                 return match.group(1).strip()
 
-    return get_last_version(pattern=version_pattern, skip_tags=[version, get_formatted_tag(version)])
+    return get_last_version(
+        pattern=version_pattern, skip_tags=[version, get_formatted_tag(version)]
+    )
 
 
 @LoggedFunction(logger)
@@ -362,7 +372,9 @@ def get_previous_release_version(version: str) -> Optional[str]:
                 logger.debug(f"Version matches regex {commit_message}")
                 return match.group(1).strip()
 
-    return get_last_version(pattern=release_version_pattern, skip_tags=[version, get_formatted_tag(version)])
+    return get_last_version(
+        pattern=release_version_pattern, skip_tags=[version, get_formatted_tag(version)]
+    )
 
 
 @LoggedFunction(logger)

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -10,12 +10,12 @@ from semantic_release.history import (
     PatternVersionDeclaration,
     TomlVersionDeclaration,
     VersionDeclaration,
+    get_current_release_version,
+    get_current_release_version_by_commits,
+    get_current_release_version_by_tag,
     get_current_version,
     get_current_version_by_config_file,
     get_current_version_by_tag,
-    get_current_release_version,
-    get_current_release_version_by_tag,
-    get_current_release_version_by_commits,
     get_new_version,
     get_previous_version,
     load_version_declarations,
@@ -81,10 +81,12 @@ def test_current_version_should_run_with_tag_only(mocker):
 
 
 @mock.patch("semantic_release.history.get_last_version", return_value=None)
-@mock.patch("semantic_release.history.get_current_release_version_by_commits", return_value="0.0.0")
+@mock.patch(
+    "semantic_release.history.get_current_release_version_by_commits",
+    return_value="0.0.0",
+)
 def test_current_release_version_should_return_default_version(
-    mock_last_version,
-    mock_current_release_version_by_commits
+    mock_last_version, mock_current_release_version_by_commits
 ):
     assert "0.0.0" == get_current_release_version()
 
@@ -227,7 +229,11 @@ class TestVersionPattern:
         "str, path, pattern",
         [
             ("path:pattern", Path("path"), r"pattern"),
-            ("path:Version: {version}", Path("path"), r"Version: (\d+\.\d+\.\d+(-beta\.\d+)?)"),
+            (
+                "path:Version: {version}",
+                Path("path"),
+                r"Version: (\d+\.\d+\.\d+(-beta\.\d+)?)",
+            ),
         ],
     )
     def test_from_pattern(self, str, path, pattern):
@@ -414,7 +420,10 @@ class TestVersionPattern:
                         version_variable = "path:__version__"
                         """,
             patterns=[
-                (Path("path"), r'__version__ *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']'),
+                (
+                    Path("path"),
+                    r'__version__ *[:=] *["\'](\d+\.\d+\.\d+(-beta\.\d+)?)["\']',
+                ),
             ],
         ),
         dict(

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -6,7 +6,7 @@ import pytest
 from git import GitCommandError, Repo, TagObject
 
 from semantic_release.errors import GitError, HvcsRepoParseError
-from semantic_release.history import version_pattern, release_version_pattern
+from semantic_release.history import release_version_pattern, version_pattern
 from semantic_release.vcs_helpers import (
     check_repo,
     checkout,
@@ -142,8 +142,12 @@ def test_push_using_token(mock_git, mocker, actor):
     owner = "owner"
     name = "name"
     branch = "main"
-    push_new_version(auth_token=token, domain=domain, owner=owner, name=name, branch=branch)
-    server = f"https://{actor + ':' if actor else ''}{token}@{domain}/{owner}/{name}.git"
+    push_new_version(
+        auth_token=token, domain=domain, owner=owner, name=name, branch=branch
+    )
+    server = (
+        f"https://{actor + ':' if actor else ''}{token}@{domain}/{owner}/{name}.git"
+    )
     mock_git.push.assert_has_calls(
         [
             mock.call(server, branch),
@@ -162,7 +166,9 @@ def test_push_ignoring_token(mock_git, mocker):
     owner = "owner"
     name = "name"
     branch = "main"
-    push_new_version(auth_token=token, domain=domain, owner=owner, name=name, branch=branch)
+    push_new_version(
+        auth_token=token, domain=domain, owner=owner, name=name, branch=branch
+    )
     server = "origin"
     mock_git.push.assert_has_calls(
         [
@@ -388,13 +394,18 @@ def test_get_last_version(pattern, skip_tags, expected_result):
     )
     assert expected_result == get_last_version(pattern, skip_tags)
 
+
 @pytest.mark.parametrize(
     "pattern, skip_tags,expected_result",
     [
         (version_pattern, None, "2.1.0-beta.0"),
         (version_pattern, ["v2.1.0-beta.0"], "2.0.0"),
         (version_pattern, ["v2.1.0-beta.0", "v2.0.0-beta.0", "v2.0.0"], "1.1.0"),
-        (version_pattern, ["v2.1.0-beta.0", "v2.0.0-beta.0", "v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"], None),
+        (
+            version_pattern,
+            ["v2.1.0-beta.0", "v2.0.0-beta.0", "v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"],
+            None,
+        ),
         (release_version_pattern, None, "2.0.0"),
         (release_version_pattern, ["v2.0.0"], "1.1.0"),
         (release_version_pattern, ["v2.0.0", "v1.1.0", "v1.0.0", "v0.1.0"], None),


### PR DESCRIPTION
The tests were failing due to the addition of methods and tests that get the current release by tag without pulling all of the tags.  Adding a `fetch-depth` of `0` corrected the issue.   