### PR TITLE
fix: :bug: fix get_current_release_version for tag_only version_source

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -256,7 +256,7 @@ def get_current_release_version() -> str:
 
     :return: A string with the current version number
     """
-    if config.get("version_source") == "tag":
+    if config.get("version_source") in ["tag", "tag_only"]:
         return get_current_release_version_by_tag()
     else:
         return get_current_release_version_by_commits()


### PR DESCRIPTION
I _think_ this is a bug, but let me know if not...

`get_current_release_version()` doesn't work when using `tag_only` version source... it defaults back to `get_current_release_version_by_commits` which may show nothing