### PR TITLE
fix: Wrong current release version captured when patch has more than one digit

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 prerelease_pattern = f"-{config.get('prerelease_tag')}\.\d+"
 version_pattern = f"(\d+\.\d+\.\d+({prerelease_pattern})?)"
-release_version_pattern = f"(\d+\.\d+\.\d+(?!{prerelease_pattern}))"
+release_version_pattern = f"(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))"
 
 release_version_regex = rf"{release_version_pattern}"
 version_regex = rf"{version_pattern}"

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -124,17 +124,10 @@ class TestGetPreviousVersion:
 class TestGetCurrentReleaseVersionByCommits:
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0"), ("13", "0.9.13"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0-beta.1"), ("13", "0.9.1-beta.1"), ("13", "0.9.0")],
     )
     def test_should_return_correct_version(self):
-        assert get_current_release_version_by_commits() == "0.10.0"
-
-    @mock.patch(
-        "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.0.24-beta.10"), ("13", "0.0.23"), ("14", "0.0.21-beta.0"), ("15", "0.0.19")],
-    )
-    def test_should_return_correct_version_with_prerelease(self):
-        assert get_current_release_version_by_commits() == "0.0.23"
+        assert get_current_release_version_by_commits() == "0.9.0"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
@@ -149,6 +142,13 @@ class TestGetCurrentReleaseVersionByCommits:
     )
     def test_should_return_correct_version_from_prerelease(self):
         assert get_current_release_version_by_commits() == "0.9.0"
+
+    @mock.patch(
+        "semantic_release.history.get_commit_log",
+        lambda: [("211", "0.0.24-beta.10"), ("13", "0.0.23"), ("14", "0.0.21-beta.0"), ("15", "0.0.19")],
+    )
+    def test_should_return_correct_version_from_large_prerelease(self):
+        assert get_current_release_version_by_commits() == "0.0.23"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
@@ -176,7 +176,6 @@ class TestGetNewVersion:
         assert get_new_version("0.0.0", "0.0.0", "patch") == "0.0.1"
         assert get_new_version("0.1.0", "0.1.0", "patch") == "0.1.1"
         assert get_new_version("10.0.9", "10.0.9", "patch") == "10.0.10"
-        assert get_new_version("10.0.19", "10.0.19", "patch") == "10.0.20"
 
     def test_none_bump(self):
         assert get_new_version("1.0.0", "1.0.0", None) == "1.0.0"
@@ -196,16 +195,6 @@ class TestGetNewVersion:
         assert get_new_version("0.9.0-beta.1", "1.0.0", "major", True) == "2.0.0-beta.1"
         assert get_new_version("0.9.0-beta.1", "1.0.0", "minor", True) == "1.1.0-beta.1"
         assert get_new_version("0.9.0-beta.1", "1.0.0", "patch", True) == "1.0.1-beta.1"
-
-        assert get_new_version("1.0.11-beta.11", "1.0.10", None, True) == "1.0.11-beta.12"
-        assert get_new_version("1.0.11-beta.11", "1.0.10", "major", True) == "2.0.0-beta.1"
-        assert get_new_version("1.0.11-beta.11", "1.0.10", "minor", True) == "1.1.0-beta.1"
-        assert get_new_version("1.0.11-beta.11", "1.0.10", "patch", True) == "1.0.11-beta.12"
-
-        assert get_new_version("1.0.11-beta.11", "1.0.11", None) == "1.0.11"
-        assert get_new_version("1.0.11-beta.11", "1.0.11", "major") == "2.0.0"
-        assert get_new_version("1.0.11-beta.11", "1.0.11", "minor") == "1.1.0"
-        assert get_new_version("1.0.11-beta.11", "1.0.11", "patch") == "1.0.12"
 
         with pytest.raises(ValueError):
             get_new_version("0.9.0", "1.0.0", None, True)

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -169,6 +169,7 @@ class TestGetNewVersion:
         assert get_new_version("0.0.0", "0.0.0", "patch") == "0.0.1"
         assert get_new_version("0.1.0", "0.1.0", "patch") == "0.1.1"
         assert get_new_version("10.0.9", "10.0.9", "patch") == "10.0.10"
+        assert get_new_version("10.0.19", "10.0.19", "patch") == "10.0.20"
 
     def test_none_bump(self):
         assert get_new_version("1.0.0", "1.0.0", None) == "1.0.0"
@@ -188,6 +189,11 @@ class TestGetNewVersion:
         assert get_new_version("0.9.0-beta.1", "1.0.0", "major", True) == "2.0.0-beta.1"
         assert get_new_version("0.9.0-beta.1", "1.0.0", "minor", True) == "1.1.0-beta.1"
         assert get_new_version("0.9.0-beta.1", "1.0.0", "patch", True) == "1.0.1-beta.1"
+
+        assert get_new_version("1.0.1-beta.11", "1.0.0", None, True) == "1.0.1-beta.12"
+        assert get_new_version("1.0.1-beta.11", "1.0.0", "major", True) == "2.0.0-beta.11"
+        assert get_new_version("1.0.1-beta.11", "1.0.0", "minor", True) == "1.1.0-beta.11"
+        assert get_new_version("1.0.1-beta.11", "1.0.0", "patch", True) == "1.0.1-beta.12"
 
         with pytest.raises(ValueError):
             get_new_version("0.9.0", "1.0.0", None, True)

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -124,10 +124,17 @@ class TestGetPreviousVersion:
 class TestGetCurrentReleaseVersionByCommits:
     @mock.patch(
         "semantic_release.history.get_commit_log",
-        lambda: [("211", "0.10.0-beta.1"), ("13", "0.9.1-beta.1"), ("13", "0.9.0")],
+        lambda: [("211", "0.10.0"), ("13", "0.9.13"), ("13", "0.9.0")],
     )
     def test_should_return_correct_version(self):
-        assert get_current_release_version_by_commits() == "0.9.0"
+        assert get_current_release_version_by_commits() == "0.10.0"
+
+    @mock.patch(
+        "semantic_release.history.get_commit_log",
+        lambda: [("211", "0.0.24-beta.10"), ("13", "0.0.23"), ("14", "0.0.21-beta.0"), ("15", "0.0.19")],
+    )
+    def test_should_return_correct_version_with_prerelease(self):
+        assert get_current_release_version_by_commits() == "0.0.23"
 
     @mock.patch(
         "semantic_release.history.get_commit_log",
@@ -190,10 +197,15 @@ class TestGetNewVersion:
         assert get_new_version("0.9.0-beta.1", "1.0.0", "minor", True) == "1.1.0-beta.1"
         assert get_new_version("0.9.0-beta.1", "1.0.0", "patch", True) == "1.0.1-beta.1"
 
-        assert get_new_version("1.0.1-beta.11", "1.0.0", None, True) == "1.0.1-beta.12"
-        assert get_new_version("1.0.1-beta.11", "1.0.0", "major", True) == "2.0.0-beta.11"
-        assert get_new_version("1.0.1-beta.11", "1.0.0", "minor", True) == "1.1.0-beta.11"
-        assert get_new_version("1.0.1-beta.11", "1.0.0", "patch", True) == "1.0.1-beta.12"
+        assert get_new_version("1.0.11-beta.11", "1.0.10", None, True) == "1.0.11-beta.12"
+        assert get_new_version("1.0.11-beta.11", "1.0.10", "major", True) == "2.0.0-beta.1"
+        assert get_new_version("1.0.11-beta.11", "1.0.10", "minor", True) == "1.1.0-beta.1"
+        assert get_new_version("1.0.11-beta.11", "1.0.10", "patch", True) == "1.0.11-beta.12"
+
+        assert get_new_version("1.0.11-beta.11", "1.0.11", None) == "1.0.11"
+        assert get_new_version("1.0.11-beta.11", "1.0.11", "major") == "2.0.0"
+        assert get_new_version("1.0.11-beta.11", "1.0.11", "minor") == "1.1.0"
+        assert get_new_version("1.0.11-beta.11", "1.0.11", "patch") == "1.0.12"
 
         with pytest.raises(ValueError):
             get_new_version("0.9.0", "1.0.0", None, True)


### PR DESCRIPTION
Version in init file: 0.0.24-beta.0
Detected current release version: 0.0.24
Detected current version: 0.0.2
Generated new version: 0.0.3

Tested the current regex pattern in isolation against the above version and see that match[1] is stripping the 4 in the patch version


Logs:

debug: Parsing current version: path=PosixPath('src/analytics_calc/init.py') pattern='version *[:=] *["\'](https://github.com/relekang/python-semantic-release/pull/%5Cd+%5C.%5Cd+%5C.%5Cd+(-beta%5C.%5Cd+)?)["\']' num_matches=1
debug: Regex matched version: 0.0.24
debug: get_current_version_by_config_file -> 0.0.24
debug: get_current_release_version_by_commits()
debug: Checking commit 19569b7cf15c3d21c7ed45dc335a386aed4d997e
debug: Checking commit 32ae4df6ee88c31e145f5109aa89c782c1c4795c
debug: Checking commit ccee325f58b449cdce1e623313efe7e1bbe6657d
debug: Checking commit 9a951310467c011f7050efead12059a5ce8537bc
debug: Checking commit c22ae08de4193e9c450d3d24fd07722d1a10fe6f
debug: Checking commit f453ba3f1e76e6d62c5a49ddc15f475401d8d66d
debug: Version matches regex 0.0.24-beta.0
debug:
debug: Automatically generated by python-semantic-release
debug: get_current_release_version_by_commits -> 0.0.2
Current version: 0.0.24, Current release version: 0.0.2
debug: evaluate_version_bump('0.0.24', 'patch')
debug: evaluate_version_bump -> patch
debug: get_new_version('0.0.24', '0.0.2', 'patch', True)