### PR TITLE
fix: Ensure that assets can be uploaded successfully on custom github servers

### DIFF
--- a/semantic_release/hvcs.py
+++ b/semantic_release/hvcs.py
@@ -2,7 +2,6 @@
 """
 import logging
 import mimetypes
-from optparse import Option
 import os
 from typing import Any, Optional, Union, cast
 from urllib.parse import urlsplit
@@ -221,7 +220,6 @@ class Github(Base):
         :return: ID of found release
         """
         try:
-            print(Github.api_url())
             response = Github.session().get(
                 f"{Github.api_url()}/repos/{owner}/{repo}/releases/tags/{tag}"
             )

--- a/tests/test_hvcs.py
+++ b/tests/test_hvcs.py
@@ -373,6 +373,7 @@ class GithubReleaseTests(TestCase):
         "https://uploads.github.com/repos/relekang/rmoq/releases/1/assets"
         "?name=testupload.md"
     )
+    upload_url = "https://uploads.github.com/repos/relekang/rmoq/releases/1/assets{?name,label}"
 
     @responses.activate
     @mock.patch("semantic_release.hvcs.Github.token", return_value="super-token")
@@ -483,6 +484,15 @@ class GithubReleaseTests(TestCase):
         with open(dummy_file_path, "w") as dummy_file:
             dummy_file.write(dummy_content)
 
+        required_payload = {"upload_url": self.upload_url}
+        responses.add(
+            responses.GET,
+            self.edit_url,
+            status=200,
+            body= json.dumps(required_payload),
+            content_type="application/json",
+        )
+
         def request_callback(request):
             self.assertEqual(request.body.decode().replace("\r\n", "\n"), dummy_content)
             self.assertEqual(request.url, self.asset_url_params)
@@ -513,7 +523,15 @@ class GithubReleaseTests(TestCase):
         )
         with open(dummy_file_path, "w") as dummy_file:
             dummy_file.write(dummy_content)
-
+        
+        required_payload = {"upload_url": self.upload_url}
+        responses.add(
+            responses.GET,
+            self.edit_url,
+            status=200,
+            body= json.dumps(required_payload),
+            content_type="application/json",
+        )
         def request_callback(request):
             self.assertEqual(request.body.decode().replace("\r\n", "\n"), dummy_content)
             self.assertEqual(request.url, self.asset_no_extension_url_params)
@@ -544,6 +562,15 @@ class GithubReleaseTests(TestCase):
         dummy_content = "# Test File\n\n*Dummy asset for testing uploads.*"
         with open(dummy_file_path, "w") as dummy_file:
             dummy_file.write(dummy_content)
+
+        required_payload = {"upload_url": self.upload_url}
+        responses.add(
+            responses.GET,
+            self.edit_url,
+            status=200,
+            body= json.dumps(required_payload),
+            content_type="application/json",
+        )
 
         def request_callback(request):
             self.assertEqual(request.body.decode().replace("\r\n", "\n"), dummy_content)


### PR DESCRIPTION
Allows custom github servers to have assets uploaded and compatible with github.com as well.,

Note: `hvcs_api_domain` is really `hvcs_api_root` for github enterprise servers, as the API root would typically be `https://my_custo_github.com/api/v3`.

Closes: #456 