### PR TITLE
fix: ignore dependencies versions bump when parsing version from commit logs

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 prerelease_pattern = f"-{config.get('prerelease_tag')}\.\d+"
 version_pattern = f"(\d+\.\d+\.\d+({prerelease_pattern})?)"
-release_version_pattern = f"(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))"
+release_version_pattern = f"v?(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))"
 
 release_version_regex = rf"{release_version_pattern}"
 version_regex = rf"{version_pattern}"

--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -388,7 +388,7 @@ def get_current_release_version_by_commits() -> str:
     """
     for commit_hash, commit_message in get_commit_log():
         logger.debug(f"Checking commit {commit_hash}")
-        match = re.search(rf"{release_version_pattern}", commit_message)
+        match = re.match(rf"{release_version_pattern}", commit_message)
         if match:
             logger.debug(f"Version matches regex {commit_message}")
             return match.group(1).strip()

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -82,7 +82,7 @@ def get_last_version(pattern, skip_tags=None) -> Optional[str]:
 
         match = re.search(rf"{pattern}", i.name)
         if match:
-            return match.group(0).strip()
+            return match.group(1).strip()
 
     return None
 

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -162,6 +162,17 @@ class TestGetCurrentReleaseVersionByCommits:
     def test_should_return_correct_version_without_prerelease(self):
         assert get_current_release_version_by_commits() == "7.28.0"
 
+    @mock.patch(
+        "semantic_release.history.get_commit_log",
+        lambda: [
+            ("211", "chore(deps): bump some-deps to 0.6.0"),
+            ("13", "fix(deps): bump other-deps to 1.2.3"),
+            ("13", "8.9.2"),
+        ],
+    )
+    def test_should_ignore_deps_version_bump(self):
+        assert get_current_release_version_by_commits() == "8.9.2"
+
 
 class TestGetNewVersion:
     def test_major_bump(self):

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -359,9 +359,9 @@ def test_checkout_should_checkout_correct_branch(mock_git):
 @pytest.mark.parametrize(
     "pattern, skip_tags,expected_result",
     [
-        ("\d+.\d+.\d+", None, "2.0.0"),
-        ("\d+.\d+.\d+", ["v2.0.0"], "1.1.0"),
-        ("\d+.\d+.\d+", ["v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"], None),
+        ("(\d+.\d+.\d+)", None, "2.0.0"),
+        ("(\d+.\d+.\d+)", ["v2.0.0"], "1.1.0"),
+        ("(\d+.\d+.\d+)", ["v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"], None),
     ],
 )
 def test_get_last_version(pattern, skip_tags, expected_result):


### PR DESCRIPTION
Fix #442 