### PR TITLE
fix: ignore dependencies versions bump when parsing version from commit logs

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -29,14 +29,19 @@ def get_prerelease_pattern():
     return f"-{config.get('prerelease_tag')}\.\d+"
 
 
+def get_pattern_with_commit_subject(pattern):
+    escaped_commit_subject = re.escape(config.get("commit_subject"))
+    return escaped_commit_subject.replace("\{version\}", pattern)
+
+
 def get_version_pattern():
     prerelease_pattern = get_prerelease_pattern()
-    return f"(\d+\.\d+\.\d+({prerelease_pattern})?)"
+    return get_pattern_with_commit_subject(f"(\d+\.\d+\.\d+({prerelease_pattern})?)")
 
 
 def get_release_version_pattern():
     prerelease_pattern = get_prerelease_pattern()
-    return f"(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))"
+    return get_pattern_with_commit_subject(f"v?(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))")
 
 
 class VersionDeclaration(ABC):
@@ -401,7 +406,7 @@ def get_current_release_version_by_commits() -> str:
 
     for commit_hash, commit_message in get_commit_log():
         logger.debug(f"Checking commit {commit_hash}")
-        match = release_version_re.search(commit_message)
+        match = release_version_re.match(commit_message)
         if match:
             logger.debug(f"Version matches regex {commit_message}")
             return match.group(1).strip()

--- a/semantic_release/vcs_helpers.py
+++ b/semantic_release/vcs_helpers.py
@@ -82,7 +82,7 @@ def get_last_version(pattern, skip_tags=None) -> Optional[str]:
 
         match = re.search(pattern, i.name)
         if match:
-            return match.group(0).strip()
+            return match.group(1).strip()
 
     return None
 

--- a/tests/history/test_version.py
+++ b/tests/history/test_version.py
@@ -163,6 +163,26 @@ class TestGetCurrentReleaseVersionByCommits:
         assert get_current_release_version_by_commits() == "7.28.0"
 
 
+    @mock.patch(
+        "semantic_release.history.get_commit_log",
+        lambda: [("222", "chore(deps): bump random lib to 7.29.0"), ("211", "7.28.0"), ("13", "7.27.0")],
+    )
+    def test_should_return_correct_version_ignoring_dependency_bumps(self):
+        assert get_current_release_version_by_commits() == "7.28.0"
+
+
+    @mock.patch(
+        "semantic_release.history.get_commit_log",
+        lambda: [("222", "7.29.0"), ("211", "chore(release): 7.28.0"), ("13", "7.27.0")],
+    )
+    
+    def test_should_return_correct_version_with_commit_subject(self):
+        with mock.patch(
+            "semantic_release.history.config.get", wrapped_config_get(commit_subject="chore(release): {version}")
+        ):
+            assert get_current_release_version_by_commits() == "7.28.0"
+
+
 class TestGetNewVersion:
     def test_major_bump(self):
         assert get_new_version("0.0.0", "0.0.0", "major") == "1.0.0"

--- a/tests/test_vcs_helpers.py
+++ b/tests/test_vcs_helpers.py
@@ -359,9 +359,9 @@ def test_checkout_should_checkout_correct_branch(mock_git):
 @pytest.mark.parametrize(
     "pattern, skip_tags,expected_result",
     [
-        ("\d+.\d+.\d+", None, "2.0.0"),
-        ("\d+.\d+.\d+", ["v2.0.0"], "1.1.0"),
-        ("\d+.\d+.\d+", ["v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"], None),
+        ("(\d+.\d+.\d+)", None, "2.0.0"),
+        ("(\d+.\d+.\d+)", ["v2.0.0"], "1.1.0"),
+        ("(\d+.\d+.\d+)", ["v0.1.0", "v1.0.0", "v1.1.0", "v2.0.0"], None),
     ],
 )
 def test_get_last_version(pattern, skip_tags, expected_result):


### PR DESCRIPTION
Builds upon https://github.com/relekang/python-semantic-release/pull/472 from @browniebroke and adds the commit_subject functionality
Fixes: https://github.com/relekang/python-semantic-release/issues/442