### PR TITLE
feat: add ADDITIONAL_OPTIONS for gh action

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -17,5 +17,8 @@ git config --global user.name "github-actions"
 git config --global user.email "action@github.com"
 
 # Run Semantic Release
-/semantic-release/.venv/bin/python -m semantic_release publish -v DEBUG \
-  -D commit_author="github-actions <action@github.com>"
+/semantic-release/.venv/bin/python \
+  -m semantic_release publish \
+  -v DEBUG \
+  -D commit_author="github-actions <action@github.com>" \
+  "${INPUT_ADDITIONAL_OPTIONS}"

--- a/docs/automatic-releases/github-actions.rst
+++ b/docs/automatic-releases/github-actions.rst
@@ -10,15 +10,17 @@ Inputs
 +--------------------------+----------------------------------------------------------------------------------------+
 | Input                    | Description                                                                            |
 +==========================+========================================================================================+
-| ``github_token``         | See :ref:`env-gh_token`. this is usually set to ``${{ secrets.GITHUB_TOKEN }}``. |
+| ``github_token``         | See :ref:`env-gh_token`. this is usually set to ``${{ secrets.GITHUB_TOKEN }}``.       |
 +--------------------------+----------------------------------------------------------------------------------------+
 | ``pypi_token``           | See :ref:`env-pypi_token`.                                                             |
 +--------------------------+----------------------------------------------------------------------------------------+
-| ``repository_username``  | See :ref:`env-repository_username`.                                                          |
+| ``repository_username``  | See :ref:`env-repository_username`.                                                    |
 +--------------------------+----------------------------------------------------------------------------------------+
-| ``repository_password``  | See :ref:`env-repository_password`.                                                          |
+| ``repository_password``  | See :ref:`env-repository_password`.                                                    |
 +--------------------------+----------------------------------------------------------------------------------------+
 | ``directory``            | A sub-directory to ``cd`` into before running. Defaults to the root of the repository. |
++--------------------------+----------------------------------------------------------------------------------------+
+| ``additional_options``   | Additional :ref:`cmd-common-options` for the ``publish`` command. Example: ``--noop``  |
 +--------------------------+----------------------------------------------------------------------------------------+
 
 Other options are taken from your regular configuration file.

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -55,6 +55,8 @@ Publish will do a sequence of things:
 
 Some of these steps may be disabled based on your configuration.
 
+.. _cmd-common-options:
+
 Common Options
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add `ADDITIONAL_OPTIONS` as an additional command for the github action.


Using it with `--noop` on PRs as shown below allows to verify that new configurations or versions will run successfully on the main branch:

```yaml
name: Semantic Release

on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - master

jobs:
  noop-release:
    if: github.ref != 'refs/heads/master'
    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v2
      with:
        fetch-depth: 0

    - name: Python Semantic Release Test
      uses: relekang/python-semantic-release@master
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        repository_username: __token__
        repository_password: ${{ secrets.PYPI_TOKEN }}
        additional_options: --noop
  release:
    if: github.ref == 'refs/heads/master'
    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v2
      with:
        fetch-depth: 0

    - name: Python Semantic Release
      uses: relekang/python-semantic-release@master
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        repository_username: __token__
        repository_password: ${{ secrets.PYPI_TOKEN }}
```