### PR TITLE
fix: allow empty additional options

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -21,4 +21,4 @@ git config --global user.email "action@github.com"
   -m semantic_release publish \
   -v DEBUG \
   -D commit_author="github-actions <action@github.com>" \
-  "${INPUT_ADDITIONAL_OPTIONS}"
+  ${INPUT_ADDITIONAL_OPTIONS}


### PR DESCRIPTION
I added double quotes to fulfill https://www.shellcheck.net/wiki/SC2086 but this doesn't work for the default (empty env var).