### PR TITLE
fix: Declare additional_options as action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ name: 'Python Semantic Release'
 description: 'Automatic Semantic Versioning for Python projects'
 
 inputs:
+  additional_options:
+    description: 'Additional options for the publish command. Example: --noop'
+    required: false
   directory:
     description: 'Sub-directory to cd into before running semantic-release'
     default: '.'


### PR DESCRIPTION
Fixes the warning displayed at the start of an action run:

![image](https://user-images.githubusercontent.com/1481961/181001928-261efa36-d0a0-4448-85e9-9b29ccd1c86d.png)
