### PR TITLE
fix(cli): fail with exit code 2 when no subcommand is given to `semantic-release`

### DIFF
--- a/src/semantic_release/cli/commands/main.py
+++ b/src/semantic_release/cli/commands/main.py
@@ -61,6 +61,7 @@ class Cli(click.MultiCommand):
     cls=Cli,
     context_settings={
         "help_option_names": ["-h", "--help"],
+        "resilient_parsing": True,
     },
 )
 @click.version_option(

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -60,12 +60,12 @@ def test_main_prints_version_and_exits(run_cli: RunCliFn):
     assert result.output == f"semantic-release, version {__version__}\n"
 
 
-def test_main_no_args_passes_w_help_text():
+def test_main_no_args_fails_w_help_text():
     from semantic_release.cli.commands.main import main
 
     cli_cmd = [MAIN_PROG_NAME]
     result = CliRunner().invoke(main, prog_name=cli_cmd[0])
-    assert_successful_exit_code(result, cli_cmd)
+    assert_exit_code(2, result, cli_cmd)
     assert "Usage: " in result.output
 
 


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Provide better feedback to automation systems when subcommand is not given

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

Updated the test case that validates what happens when no arguments are given.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/latest/contributing.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] Appropriate End-to-End tests added/updated

- [x] N/A ~~Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)~~
