### PR TITLE
Fix(doc) alternatives to root_options

### DIFF
--- a/docs/configuration/automatic-releases/github-actions.rst
+++ b/docs/configuration/automatic-releases/github-actions.rst
@@ -371,9 +371,9 @@ to the remote repository. This option is equivalent to adding either ``--push`` 
 """"""""""""""""
 
 .. important::
-  This option has been removed in v10.0.0 and newer because of a
-  command injection vulnerability. Please update as to v10.0.0 as soon
-  as possible.
+  This option has been removed in v10.0.0 and newer because of a command injection
+  vulnerability. Please update as to v10.0.0 as soon as possible. See
+  :ref:`Upgrading to v10 <upgrade_v10-root_options>` for more information.
 
 Additional options for the main ``semantic-release`` command, which will come
 before the :ref:`version <cmd-version>` subcommand.
@@ -382,7 +382,7 @@ before the :ref:`version <cmd-version>` subcommand.
 
   .. code:: yaml
 
-    - uses: python-semantic-release/python-semantic-release@v10.0.2
+    - uses: python-semantic-release/python-semantic-release@v9
       with:
         root_options: "-vv --noop"
 
@@ -688,9 +688,9 @@ This is useful for testing the action without actually publishing anything.
 """"""""""""""""
 
 .. important::
-  This option has been removed in v10.0.0 and newer because of a
-  command injection vulnerability. Please update as to v10.0.0 as soon
-  as possible.
+  This option has been removed in v10.0.0 and newer because of a command injection
+  vulnerability. Please update as to v10.0.0 as soon as possible. See
+  :ref:`Upgrading to v10 <upgrade_v10-root_options>` for more information.
 
 Additional options for the main ``semantic-release`` command, which will come
 before the :ref:`publish <cmd-publish>` subcommand.
@@ -699,7 +699,7 @@ before the :ref:`publish <cmd-publish>` subcommand.
 
   .. code:: yaml
 
-    - uses: python-semantic-release/publish-action@v10.0.2
+    - uses: python-semantic-release/publish-action@v9
       with:
         root_options: "-vv --noop"
 

--- a/docs/upgrading/10-upgrade.rst
+++ b/docs/upgrading/10-upgrade.rst
@@ -42,18 +42,51 @@ This vulnerability existed in both the
 
 For the main :ref:`python-semantic-release/python-semantic-release <gh_actions-psr>` action,
 the following inputs are now available (in place of the old ``root_options`` parameter):
+:ref:`gh_actions-psr-inputs-config_file`, :ref:`gh_actions-psr-inputs-noop`,
+:ref:`gh_actions-psr-inputs-strict`, and :ref:`gh_actions-psr-inputs-verbosity`.
 
-- :ref:`gh_actions-psr-inputs-config_file`
-- :ref:`gh_actions-psr-inputs-noop`
-- :ref:`gh_actions-psr-inputs-strict`
-- :ref:`gh_actions-psr-inputs-verbosity`
+  **Example migration**
+
+  If you previously had the following in your GitHub Actions workflow file:
+
+  .. code:: yaml
+
+    - uses: python-semantic-release/python-semantic-release@v9
+      with:
+        root_options: "-vv --strict"
+
+  It would be updated to:
+
+  .. code:: yaml
+
+    - uses: python-semantic-release/python-semantic-release@v10
+      with:
+        strict: true
+        verbosity: 2
 
 For the :ref:`python-semantic-release/publish-action <gh_actions-publish>` action,
 the following inputs are now available (in place of the old ``root_options`` parameter):
+:ref:`gh_actions-publish-inputs-config_file`, :ref:`gh_actions-publish-inputs-noop`,
+and :ref:`gh_actions-publish-inputs-verbosity`.
 
-- :ref:`gh_actions-publish-inputs-config_file`
-- :ref:`gh_actions-publish-inputs-noop`
-- :ref:`gh_actions-publish-inputs-verbosity`
+  **Example migration**
+
+  If you previously had the following in your GitHub Actions workflow file:
+
+  .. code:: yaml
+
+    - uses: python-semantic-release/publish-action@v9
+      with:
+        root_options: "-v -c /path/to/releaserc.yaml"
+
+  It would be updated to:
+
+  .. code:: yaml
+
+    - uses: python-semantic-release/publish-action@v10
+      with:
+        config_file: /path/to/releaserc.yaml
+        verbosity: 1
 
 
 .. _upgrade_v10-changelog_format-1_line_commit_subjects:


### PR DESCRIPTION
## Purpose
Provide a new example next to the old root_option.


## Rationale
Even though it shows the v10 release, it still shows the no longer supported syntax. 


## How did you test?
I have read the docs and applied it to my project. https://github.com/bartdorlandt/convert_poetry2uv/


## How to Verify
Check my release, and these options are already in the docs.

