### PR TITLE
Doc(github-actions.rst) fixes the GitHub Actions example

### DIFF
--- a/docs/configuration/automatic-releases/github-actions.rst
+++ b/docs/configuration/automatic-releases/github-actions.rst
@@ -953,6 +953,9 @@ to the GitHub Release Assets as well.
               path: dist
               if-no-files-found: error
 
+        outputs:
+          released: ${{ steps.release.outputs.released || 'false' }}
+
       deploy:
         # 1. Separate out the deploy step from the publish step to run each step at
         #    the least amount of token privilege


### PR DESCRIPTION
## Purpose
The example deploy job in github-actions.rst requires outputs.released to be set to true but it is never set to true. This change adds this output, similar to how it is done in the workflow file for python-semantic-release. 

Though I am not sure if it is conditional on the success of the release, I still think the example should be working.

---

## PR Completion Checklist

- [ ] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
