### PR TITLE
chore(scripts): add docs development script

### DIFF
--- a/scripts/watch_docs.sh
+++ b/scripts/watch_docs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if command -v realpath >/dev/null 2>&1; then
+    PROJ_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+elif command -v readlink >/dev/null 2>&1; then
+    PROJ_ROOT=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")
+else
+    PROJ_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+fi
+
+[ -z "$VIRTUAL_ENV" ] && VIRTUAL_ENV=".venv"
+SPHINX_AUTOBUILD_EXE="$VIRTUAL_ENV/bin/sphinx-autobuild"
+
+cd "$PROJ_ROOT" || exit 1
+
+if [ ! -f "$SPHINX_AUTOBUILD_EXE" ]; then
+    printf '%s\n' "sphinx-autobuild is not installed in the virtual environment. Please install the docs extras."
+    exit 1
+fi
+
+rm -rf docs/_build/html docs/api/modules
+
+exec "$SPHINX_AUTOBUILD_EXE" docs docs/_build/html --open-browser --port 9000 --ignore docs/api/modules


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- adds a script to automate cleaning and building apidocs including the `sphinx-autobuild` command properly

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

Trying to prevent the excessive loops of the file watcher when the api docs are created initially.

## How did you test?

Manual execution of the script from different current working directories

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
