### PR TITLE
ci(github): add python 3.14 as new e2e testing environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       # It was a bit of overkill before testing every minor version, and since this project is all about
       # SemVer, we should expect Python to adhere to that model to. Therefore Only test across 2 OS's but
       # the lowest supported minor version and the latest stable minor version (just in case).
-      python-versions-linux: '["3.8", "3.13"]'
+      python-versions-linux: '["3.8", "3.14"]'
       # Since the test suite takes ~4 minutes to complete on windows, and windows is billed higher
       # we are only going to run it on the oldest version of python we support. The older version
       # will be the most likely area to fail as newer minor versions maintain compatibility.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,8 +76,8 @@ jobs:
       # It was a bit of overkill before testing every minor version, and since this project is all about
       # SemVer, we should expect Python to adhere to that model to. Therefore Only test across 2 OS's but
       # the lowest supported minor version and the latest stable minor version.
-      python-versions-linux: '["3.8", "3.13"]'
-      python-versions-windows: '["3.8", "3.13"]'
+      python-versions-linux: '["3.8", "3.14"]'
+      python-versions-windows: '["3.8", "3.14"]'
       files-changed: ${{ needs.eval-changes.outputs.any-file-changes }}
       build-files-changed: ${{ needs.eval-changes.outputs.build-changes }}
       ci-files-changed: ${{ needs.eval-changes.outputs.ci-changes }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -14,6 +14,11 @@ on:
         type: boolean
         required: true
         default: true
+      python3-14:
+        description: 'Test Python 3.14?'
+        type: boolean
+        required: true
+        default: true
       python3-13:
         description: 'Test Python 3.13?'
         type: boolean
@@ -79,6 +84,7 @@ jobs:
                 "3.11" if str(os.getenv("INPUT_PY3_11", False)).lower() == str(True).lower() else None,
                 "3.12" if str(os.getenv("INPUT_PY3_12", False)).lower() == str(True).lower() else None,
                 "3.13" if str(os.getenv("INPUT_PY3_13", False)).lower() == str(True).lower() else None,
+                "3.14" if str(os.getenv("INPUT_PY3_14", False)).lower() == str(True).lower() else None,
             ]))
 
             linux_versions = (
@@ -105,6 +111,7 @@ jobs:
           INPUT_PY3_11: ${{ inputs.python3-11 }}
           INPUT_PY3_12: ${{ inputs.python3-12 }}
           INPUT_PY3_13: ${{ inputs.python3-13 }}
+          INPUT_PY3_14: ${{ inputs.python3-14 }}
           INPUT_LINUX: ${{ inputs.linux }}
           INPUT_WINDOWS: ${{ inputs.windows }}
         run: |


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

Verify that python-semantic-release does in fact work on Python 3.14 (the latest stable version)

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

The main reason to test this is for installation to make sure the dependency specifications do support the latest stable version of python.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

Allowed the CI to perform the test by telling in the new baseline to start the tests from.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] N/A ~~Appropriate Unit tests added/updated~~

- [x] N/A ~~Appropriate End-to-End tests added/updated~~

- [x] N/A ~~Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)~~
