### PR TITLE
Add support for disabling SSL verification in GitLab client

### DIFF
--- a/src/semantic_release/hvcs/gitlab.py
+++ b/src/semantic_release/hvcs/gitlab.py
@@ -68,7 +68,11 @@ class Gitlab(RemoteHvcsBase):
             ).url.rstrip("/")
         )
 
-        self._client = gitlab.Gitlab(self.hvcs_domain.url, private_token=self.token)
+        self._client = gitlab.Gitlab(
+            self.hvcs_domain.url,
+            private_token=self.token,
+            ssl_verify=not allow_insecure,
+        )
         self._api_url = parse_url(self._client.api_url)
 
     @property


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

This pull request fixes a bug where `python-semantic-release` fails to create releases on self-hosted GitLab instances that use self-signed or internally-issued SSL certificates.

When the `insecure = true` flag is set in `pyproject.toml`, the release process currently fails with an `SSLCertVerificationError`, preventing users from publishing releases in their private GitLab environments. This PR ensures that the `insecure` flag is correctly honored.

**Solves:** `requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed` when running `semantic-release publish` against a self-hosted GitLab instance.

## Rationale
<!-- How did you come to this conclusion as the solution? What was your reasoning? What were you trying to do? What problems did you find and avoid? -->

The root cause of the issue is that the `allow_insecure` parameter in the `semantic_release.hvcs.gitlab.Gitlab` class was not being passed down to the underlying `python-gitlab` client.

The `gitlab.Gitlab` constructor accepts an `ssl_verify` parameter, which defaults to `True`. The `python-semantic-release` wrapper did not utilize the `allow_insecure` flag to modify this behavior. As a result, the `python-gitlab` client always attempted to verify SSL certificates, regardless of the user's configuration in `pyproject.toml`.

The solution is to explicitly pass `ssl_verify=not allow_insecure` during the initialization of the `gitlab.Gitlab` client within `semantic_release/hvcs/gitlab.py`. This directly connects the configuration option to the client's behavior, making the `insecure` flag work as intended.

Workarounds like setting `REQUESTS_CA_BUNDLE` or `GITLAB_SSL_VERIFY` environment variables were considered but are less ideal as they require extra configuration in the user's CI/CD environment rather than fixing the bug at its source.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rule out any edge cases, please
mention the rationale here.
-->

This change was validated through manual end-to-end testing in a CI/CD environment that replicates the original issue.

**Methodology:**

1.  **Forked the Repository:** Created a fork of `python-semantic-release` and applied the code change on a new branch.
2.  **CI Pipeline Setup:** Configured a GitLab CI pipeline to run against a self-hosted GitLab instance using a self-signed certificate.
3.  **Configuration:** The `pyproject.toml` file was configured with the following remote settings:
    ```toml
    [tool.semantic_release.remote]
    type = "gitlab"
    insecure = true
    gitlab_url = "https://your.self-hosted.gitlab"
    ```
4.  **Installation:** The CI job was modified to install `python-semantic-release` directly from the forked Git repository and branch.
    ```yml
    - uv pip install "git+https://github.com/your-username/python-semantic-release.git@fix/gitlab-ssl-verify"
    ```
5.  **Execution:** Ran the `semantic-release publish` command.
6.  **Validation:**
    *   **Before Fix:** The pipeline failed with the `SSLCertVerificationError`.
    *   **After Fix:** The pipeline successfully executed the `publish` step, creating a new release in the self-hosted GitLab project.

No edge cases were identified, as this change simply wires a boolean flag to its intended destination. Existing unit tests continue to pass.

## How to Verify
<!-- Please provide a list of steps to validate your solution -->

A reviewer can verify this fix by following these steps:

1.  Check out this PR branch locally.
2.  Set up a test environment pointing to a self-hosted GitLab instance that uses a self-signed or non-publicly trusted SSL certificate.
3.  In a test project, configure `pyproject.toml` as follows:
    ```toml
    [tool.semantic_release]
    # ... other settings
    [tool.semantic_release.remote]
    type = "gitlab"
    gitlab_url = "https://your.gitlab.instance"
    token = { env = "GITLAB_TOKEN" }
    insecure = true
    ```
4.  Install this patched version of `python-semantic-release`.
5.  Run `semantic-release publish`.
6.  **Expected Result:** The command should complete successfully, creating a release on the GitLab instance without any SSL errors. To confirm the failure, run the same command on the `main` branch, which should fail with the `SSLCertVerificationError`.

---

## PR Completion Checklist

- [ ] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)
- [ ] Changes Implemented & Validation pipeline succeeds
- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)
- [ ] Appropriate Unit tests added/updated
- [ ] Appropriate End-to-End tests added/updated
- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)