### PR TITLE
Fix selection of commits that modify files outside of the current working directory

### DIFF
--- a/src/semantic_release/commit_parser/conventional/options_monorepo.py
+++ b/src/semantic_release/commit_parser/conventional/options_monorepo.py
@@ -23,7 +23,7 @@ class ConventionalCommitMonorepoParserOptions(ConventionalCommitParserOptions):
     # TODO: add example into the docstring
     """Options dataclass for ConventionalCommitMonorepoParser."""
 
-    path_filters: Annotated[Tuple[str, ...], Field(validate_default=True)] = (".",)
+    path_filters: Annotated[Tuple[Path, ...], Field(validate_default=True)] = (".",)
     """
     A set of relative paths to filter commits by. Only commits with file changes that
     match these file paths or its subdirectories will be considered valid commits.
@@ -43,8 +43,8 @@ class ConventionalCommitMonorepoParserOptions(ConventionalCommitParserOptions):
     to match them literally.
     """
 
-    @classmethod
     @field_validator("path_filters", mode="before")
+    @classmethod
     def convert_strs_to_paths(cls, value: Any) -> tuple[Path, ...]:
         values = value if isinstance(value, Iterable) else [value]
         results: list[Path] = []
@@ -58,8 +58,8 @@ class ConventionalCommitMonorepoParserOptions(ConventionalCommitParserOptions):
 
         return tuple(results)
 
-    @classmethod
     @field_validator("path_filters", mode="after")
+    @classmethod
     def resolve_path(cls, dir_paths: tuple[Path, ...]) -> tuple[Path, ...]:
         return tuple(
             (
@@ -72,8 +72,8 @@ class ConventionalCommitMonorepoParserOptions(ConventionalCommitParserOptions):
             for path in dir_paths
         )
 
-    @classmethod
     @field_validator("scope_prefix", mode="after")
+    @classmethod
     def validate_scope_prefix(cls, scope_prefix: str) -> str:
         if not scope_prefix:
             return ""

--- a/src/semantic_release/commit_parser/conventional/parser_monorepo.py
+++ b/src/semantic_release/commit_parser/conventional/parser_monorepo.py
@@ -133,7 +133,8 @@ class ConventionalCommitMonorepoParser(
         unique_selection_filters: set[str] = set()
         unique_ignore_filters: set[str] = set()
 
-        for str_path in path_filters:
+        for path in path_filters:
+            str_path = path.as_posix()
             str_filter = str_path[1:] if str_path.startswith("!") else str_path
             filter_list = (
                 file_ignore_filters


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose

Targetting #1380 

This PR is unfortunately incomplete. I got stuck trying to write the automated tests, couldn’t afford more time on it. I’m creating it anyway in case hoping it can help. If not, feel free to throw it away.

The purpose of this PR is to be able to select commits that modify files outside of the current working directory (the target package directory) in a monorepo. 

For example, in a monorepo that looks like:

```
./
- src/: shared code
- projects
  - api/
    - pyproject.toml
    - src/
  - <other packages>
    - ...
```
  
this PR would allow paths like `../../src` (outside of the package relative to the current directory) or `/src` (relative to the project root) in `path_filters` in `src/projects/api/pyproject.toml` when using `commit_parser = "conventional-monorepo"`.



## Rationale

I looked into the code here:

https://github.com/python-semantic-release/python-semantic-release/blob/2dd8be7b1ae5f0504b5c4ac44e74608802e20066/src/semantic_release/commit_parser/conventional/parser_monorepo.py#L426-L428

If `Path(select_filter).is_absolute()`, select_filter starts with a `/`. Then `git_root / select_filter.rstrip("/")` is equivalent to `select_filter.rstrip("/")`. Is it a bug ?

Also, in the same function,

https://github.com/python-semantic-release/python-semantic-release/blob/2dd8be7b1ae5f0504b5c4ac44e74608802e20066/src/semantic_release/commit_parser/conventional/parser_monorepo.py#L454

will be false if `full_path="/path/to/repo/src/test.txt"` and `select_filter="/path/to/repo/project/api/../../src/test.txt"`, even though those two paths resolve to the same one.




## How did you test?
I didn’t test. I tried writing unit tests but got stuck and couldn’t afford enough time to dive deep enough.



## How to Verify
<!-- Please provide a list of steps to validate your solution -->



---

## PR Completion Checklist

- [ ] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [ ] Changes Implemented & Validation pipeline succeeds

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [ ] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
