### PR TITLE
feat(changelog): Support remote git repositories as template sources

### DIFF
--- a/docs/concepts/changelog_templates.rst
+++ b/docs/concepts/changelog_templates.rst
@@ -1035,6 +1035,101 @@ the remote VCS for each commit. Both of these are injected into the template env
 by PSR.
 
 
+.. _changelog-templates-remote:
+
+Remote Template Directories
+---------------------------
+
+*Introduced in v10.6.0*
+
+As of v10.6.0, PSR supports loading changelog templates from remote filesystems such as
+GitHub repositories, S3 buckets, HTTP servers, and other locations supported by `fsspec`_.
+This enables you to centralize your changelog templates in a shared location and reuse
+them across multiple projects.
+
+.. _fsspec: https://filesystem-spec.readthedocs.io/
+
+To use a remote template directory, set the :ref:`template_dir <config-changelog-template_dir>`
+setting to a URL supported by fsspec.
+
+Most remote protocols require additional packages. Install the appropriate
+fsspec extra for your protocol (e.g., ``fsspec[s3]`` for S3).
+Refer to the `fsspec extras documentation`_ for the full list of available protocols.
+
+.. _fsspec extras documentation: https://filesystem-spec.readthedocs.io/en/latest/#installation
+
+
+GitHub Repository (Public)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For a public GitHub repository, use the ``github://`` protocol:
+
+.. code-block:: toml
+
+    [tool.semantic_release.changelog]
+    template_dir = "github://myorg:shared-templates@main/changelog-templates"
+
+The URL format is ``github://org:repo@ref/path`` where:
+
+* ``org`` is the GitHub organization or username
+* ``repo`` is the repository name
+* ``ref`` is the branch name, tag, or commit SHA
+* ``path`` is the path to the template directory within the repository
+
+
+GitHub Repository (Private)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For private repositories, you need to provide authentication via the
+:ref:`storage_options <config-changelog-storage_options>` setting:
+
+.. code-block:: toml
+
+    [tool.semantic_release.changelog]
+    template_dir = "github://myorg:private-templates@main/changelog-templates"
+
+    [tool.semantic_release.changelog.storage_options]
+    username = { env = "GITHUB_TOKEN" }
+    token = { env = "GITHUB_TOKEN" }
+
+Refer to the `fsspec GithubFileSystem documentation`_ for details on supported
+authentication methods.
+
+.. _fsspec GithubFileSystem documentation: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.github.GithubFileSystem
+
+
+Other Supported Protocols
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Through fsspec, PSR supports many other remote filesystems including:
+
+* **HTTP/HTTPS**: ``https://example.com/templates``
+* **S3**: ``s3://bucket-name/templates``
+* **Google Cloud Storage**: ``gcs://bucket-name/templates``
+* **Azure Blob Storage**: ``az://container-name/templates``
+
+Refer to the `fsspec documentation`_ for the full list of supported filesystems and
+their respective configuration options.
+
+.. _fsspec documentation: https://filesystem-spec.readthedocs.io/en/latest/api.html#built-in-implementations
+
+
+Security Considerations
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+   Chained protocols (e.g., ``simplecache::s3://bucket/path``) are not supported for
+   security reasons.
+
+When using remote templates, be aware that:
+
+* Templates are fetched from the remote location each time the changelog is generated
+* Local path traversal protections do not apply to remote URLs (remote templates are
+  by definition external to your repository)
+* Ensure your remote template source is trusted, as templates have access to your
+  project's release history and are rendered using Jinja2
+
+
 .. _changelog-templates-custom_release_notes:
 
 Custom Release Notes

--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -727,6 +727,8 @@ reStructuredText    ``..\n    version list``
 ``template_dir``
 ****************
 
+*Remote filesystem support introduced in v10.6.0*
+
 **Type:** ``str``
 
 When files exist within the specified directory, they will be used as templates for
@@ -738,9 +740,53 @@ No default changelog template or release notes template will be used when this d
 exists and the directory is not empty. If the directory is empty, the default changelog
 template will be used.
 
+As of v10.6.0, ``template_dir`` supports remote filesystem URLs in addition to local
+paths. This allows you to store your changelog templates in a central location such
+as a GitHub repository, S3 bucket, or any other filesystem supported by `fsspec`_.
+See :ref:`changelog-templates-remote` for usage examples.
+
+.. _fsspec: https://filesystem-spec.readthedocs.io/
+
+.. warning::
+   Chained protocols (e.g., ``simplecache::s3://...``) are not supported for security
+   reasons.
+
 This option is discussed in more detail at :ref:`changelog-templates`
 
 **Default:** ``"templates"``
+
+----
+
+.. _config-changelog-storage_options:
+
+``storage_options``
+*******************
+
+*Introduced in v10.6.0*
+
+**Type:** ``dict[str, str | EnvConfigVar]``
+
+Authentication and configuration options for remote template directories. This setting
+is only relevant when using a remote URL for :ref:`template_dir <config-changelog-template_dir>`.
+
+Values can be plain strings or environment variable references using the ``{ env = "VAR_NAME" }``
+syntax.
+
+This setting is passed to the underlying `fsspec`_ filesystem. Refer to the fsspec documentation
+for available options per protocol.
+
+**Example:** GitHub private repository authentication
+
+.. code-block:: toml
+
+    [tool.semantic_release.changelog]
+    template_dir = "github://myorg:private-repo@main/templates"
+
+    [tool.semantic_release.changelog.storage_options]
+    username = { env = "GITHUB_TOKEN" }
+    token = { env = "GITHUB_TOKEN" }
+
+**Default:** ``{}`` (empty)
 
 ----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "rich ~= 14.0",
   "shellingham ~= 1.5",
   "Deprecated ~= 1.2",  # Backport of deprecated decorator for python 3.8
+  "universal-pathlib ~= 0.2.0",
 ]
 
 [project.scripts]

--- a/tests/unit/semantic_release/changelog/test_template.py
+++ b/tests/unit/semantic_release/changelog/test_template.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 # but not all of them. The testing can be expanded to cover all the options later.
 # It's not super essential as Jinja2 does most of the testing, we're just checking
 # that we can properly set the right strings in the template environment.
+from re import compile as regexp
 from textwrap import dedent
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
+from fsspec.implementations.memory import (  # type: ignore[import-untyped]
+    MemoryFileSystem,
+)
+from jinja2 import TemplateNotFound
+from upath import UPath
 
-from semantic_release.changelog.template import environment
+from semantic_release.changelog.template import (
+    UPathLoader,
+    environment,
+    recursive_render,
+)
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any
 
 EXAMPLE_TEMPLATE_FORMAT_STR = """
@@ -65,3 +77,200 @@ def test_template_env_configurable(format_map: dict[str, Any], subjects: tuple[s
     actual_result = template.render(title="important", subjects=subjects)
 
     assert expected_result == actual_result
+
+
+def test_upathloader_get_source_existing_template(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    template_file = template_dir / "test.j2"
+    template_content = "Hello {{ name }}"
+    template_file.write_text(template_content)
+    loader = UPathLoader(UPath(template_dir))
+
+    source, path, uptodate = loader.get_source(MagicMock(), "test.j2")
+
+    assert source == template_content
+    assert str(template_dir / "test.j2") in path
+    assert uptodate() is True
+
+
+def test_upathloader_get_source_missing_template_raises(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    loader = UPathLoader(UPath(template_dir))
+
+    with pytest.raises(TemplateNotFound, match=regexp(r"nonexistent\.j2")):
+        loader.get_source(MagicMock(), "nonexistent.j2")
+
+
+def test_upathloader_get_source_nested_template(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    nested_dir = template_dir / "subdir" / "nested"
+    nested_dir.mkdir(parents=True)
+    template_file = nested_dir / "deep.j2"
+    template_file.write_text("Deep template")
+    loader = UPathLoader(UPath(template_dir))
+
+    source, _, _ = loader.get_source(MagicMock(), "subdir/nested/deep.j2")
+
+    assert source == "Deep template"
+
+
+def test_upathloader_list_templates_empty_directory(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    loader = UPathLoader(UPath(template_dir))
+
+    templates = loader.list_templates()
+
+    assert templates == []
+
+
+def test_upathloader_list_templates_flat_structure(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "a.j2").write_text("A")
+    (template_dir / "b.html").write_text("B")
+    (template_dir / "c.txt").write_text("C")
+    loader = UPathLoader(UPath(template_dir))
+
+    templates = loader.list_templates()
+
+    assert sorted(templates) == ["a.j2", "b.html", "c.txt"]
+
+
+def test_upathloader_list_templates_nested_structure(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "root.j2").write_text("Root")
+    subdir = template_dir / "subdir"
+    subdir.mkdir()
+    (subdir / "nested.j2").write_text("Nested")
+    loader = UPathLoader(UPath(template_dir))
+
+    templates = loader.list_templates()
+
+    assert "root.j2" in templates
+    assert any("subdir" in t and "nested.j2" in t for t in templates)
+
+
+def test_upathloader_list_templates_excludes_directories(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "file.j2").write_text("File")
+    (template_dir / "subdir").mkdir()
+    loader = UPathLoader(UPath(template_dir))
+
+    templates = loader.list_templates()
+
+    assert templates == ["file.j2"]
+
+
+def test_upathloader_custom_encoding(tmp_path: Path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    template_file = template_dir / "unicode.j2"
+    content = "Unicode: \u00e9\u00e8\u00ea"
+    template_file.write_text(content, encoding="utf-8")
+    loader = UPathLoader(UPath(template_dir), encoding="utf-8")
+
+    source, _, _ = loader.get_source(MagicMock(), "unicode.j2")
+
+    assert source == content
+
+
+@pytest.fixture
+def clear_memory_fs():
+    # MemoryFileSystem uses a shared store, so we need to clear it
+    MemoryFileSystem.store.clear()
+    MemoryFileSystem.pseudo_dirs.clear()
+    yield
+    MemoryFileSystem.store.clear()
+    MemoryFileSystem.pseudo_dirs.clear()
+
+
+@pytest.fixture
+def memory_fs(clear_memory_fs: None) -> MemoryFileSystem:
+    return MemoryFileSystem()
+
+
+def test_upathloader_with_memory_filesystem(memory_fs: MemoryFileSystem):
+    memory_fs.mkdir("/templates")
+    memory_fs.pipe("/templates/test.j2", b"Hello {{ name }}")
+    upath = UPath("memory:///templates")
+    loader = UPathLoader(upath)
+
+    source, path, _ = loader.get_source(MagicMock(), "test.j2")
+
+    assert source == "Hello {{ name }}"
+    assert "test.j2" in path
+
+
+def test_upathloader_list_templates_memory_filesystem(memory_fs: MemoryFileSystem):
+    memory_fs.mkdir("/templates")
+    memory_fs.pipe("/templates/a.j2", b"A")
+    memory_fs.pipe("/templates/b.j2", b"B")
+    upath = UPath("memory:///templates")
+    loader = UPathLoader(upath)
+
+    templates = loader.list_templates()
+
+    assert sorted(templates) == ["a.j2", "b.j2"]
+
+
+def test_upathloader_nested_memory_filesystem(memory_fs: MemoryFileSystem):
+    memory_fs.mkdir("/templates")
+    memory_fs.mkdir("/templates/subdir")
+    memory_fs.pipe("/templates/subdir/nested.j2", b"Nested content")
+    upath = UPath("memory:///templates")
+    loader = UPathLoader(upath)
+
+    source, _, _ = loader.get_source(MagicMock(), "subdir/nested.j2")
+
+    assert source == "Nested content"
+
+
+def test_environment_with_memory_filesystem(memory_fs: MemoryFileSystem):
+    memory_fs.mkdir("/templates")
+    memory_fs.pipe("/templates/greet.j2", b"Hello, {{ name }}!")
+    upath = UPath("memory:///templates")
+    env = environment(template_dir=upath)
+
+    template = env.get_template("greet.j2")
+    result = template.render(name="Remote")
+
+    assert result == "Hello, Remote!"
+
+
+def test_recursive_render_with_memory_filesystem(
+    memory_fs: MemoryFileSystem, tmp_path: Path
+):
+    memory_fs.mkdir("/templates")
+    memory_fs.pipe("/templates/config.yaml.j2", b"key: {{ value }}")
+    memory_fs.pipe("/templates/readme.txt", b"Static file")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    upath = UPath("memory:///templates")
+    env = environment(template_dir=upath)
+    env.globals["value"] = "test_value"
+
+    rendered_paths = recursive_render(
+        template_dir=upath,
+        environment=env,
+        _root_dir=output_dir,
+    )
+
+    assert len(rendered_paths) == 2
+    assert (output_dir / "config.yaml").exists()
+    assert "key: test_value" in (output_dir / "config.yaml").read_text()
+    assert (output_dir / "readme.txt").exists()
+    assert (output_dir / "readme.txt").read_text() == "Static file"
+
+
+def test_upathloader_missing_template_memory_filesystem(memory_fs: MemoryFileSystem):
+    memory_fs.mkdir("/templates")
+    upath = UPath("memory:///templates")
+    loader = UPathLoader(upath)
+
+    with pytest.raises(TemplateNotFound, match=regexp(r"missing\.j2")):
+        loader.get_source(MagicMock(), "missing.j2")

--- a/tests/unit/semantic_release/version/declarations/test_pattern_declaration.py
+++ b/tests/unit/semantic_release/version/declarations/test_pattern_declaration.py
@@ -435,10 +435,9 @@ def test_pattern_declaration_noop_warning_on_missing_file(
 
     # Evaluate
     assert file_to_modify is None
-    assert (
-        "FILE NOT FOUND: cannot stamp version in non-existent file"
-        in capsys.readouterr().err
-    )
+    # Normalize whitespace since rich may wrap text based on terminal width
+    stderr_output = " ".join(capsys.readouterr().err.split())
+    assert "FILE NOT FOUND: cannot stamp version in non-existent file" in stderr_output
 
 
 def test_pattern_declaration_noop_warning_on_no_version_in_file(
@@ -465,10 +464,9 @@ def test_pattern_declaration_noop_warning_on_no_version_in_file(
 
     # Evaluate
     assert file_to_modify is None
-    assert (
-        "VERSION PATTERN NOT FOUND: no version to stamp in file"
-        in capsys.readouterr().err
-    )
+    # Normalize whitespace since rich may wrap text based on terminal width
+    stderr_output = " ".join(capsys.readouterr().err.split())
+    assert "VERSION PATTERN NOT FOUND: no version to stamp in file" in stderr_output
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/semantic_release/version/declarations/test_toml_declaration.py
+++ b/tests/unit/semantic_release/version/declarations/test_toml_declaration.py
@@ -279,10 +279,9 @@ def test_toml_declaration_noop_warning_on_missing_file(
 
     # Evaluate
     assert file_to_modify is None
-    assert (
-        "FILE NOT FOUND: cannot stamp version in non-existent file"
-        in capsys.readouterr().err
-    )
+    # Normalize whitespace since rich may wrap text based on terminal width
+    stderr_output = " ".join(capsys.readouterr().err.split())
+    assert "FILE NOT FOUND: cannot stamp version in non-existent file" in stderr_output
 
 
 def test_toml_declaration_noop_warning_on_no_version_in_file(
@@ -312,10 +311,9 @@ def test_toml_declaration_noop_warning_on_no_version_in_file(
 
     # Evaluate
     assert file_to_modify is None
-    assert (
-        "VERSION PATTERN NOT FOUND: no version to stamp in file"
-        in capsys.readouterr().err
-    )
+    # Normalize whitespace since rich may wrap text based on terminal width
+    stderr_output = " ".join(capsys.readouterr().err.split())
+    assert "VERSION PATTERN NOT FOUND: no version to stamp in file" in stderr_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

Closes #1401

Add support for remote repositories as template sources for changelog generation, allowing users to share templates across multiple projects without copy-paste or manual CI setup.

## Rationale

Currently, `template_dir` only accepts local filesystem paths, requiring users to either copy templates into each project, use git submodules or add manual download steps in CI workflows.

By leveraging [universal_pathlib](https://github.com/fsspec/universal_pathlib) which uses [fsspec](https://filesystem-spec.readthedocs.io/) under the hood, we can abstract the storage layer and support any fsspec-compatible backend with minimal code changes.

Security considerations:

- Chained protocols (e.g., `simplecache::file://`) are explicitly rejected to prevent bypass of path traversal checks
- Local path traversal validation is preserved for `file://`, `local://`, and bare paths
- Remote protocols skip local path validation since they cannot access the local filesystem

## How did you test?

1. Added tests covering:
   - `UPathLoader` template loading from memory filesystem
   - `StorageOptionsConfig` environment variable resolution
   - Chained protocol rejection
   - Valid `template_dir` acceptance for various protocols
   - Path traversal checks for local vs remote protocols
   - `recursive_render` with `UPath` sources

2. Validated end-to-end with a real GitHub-hosted template repository:

   ```toml
   [tool.semantic_release.changelog]
   template_dir = "github://bilelomrani1:psr-conventional-changelog-template@main/src/psr_templates/templates"
   ```

   Successfully generated changelog using remote templates.

## How to Verify

1. Install dependencies: `pip install -e .`
2. Create a test repository with a `pyproject.toml`:

   ```toml
   [tool.semantic_release.changelog]
   template_dir = "github://owner:repo@ref/path/to/templates"
   ```

4. Run `semantic-release changelog`
5. Verify templates are fetched from the remote repository

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build
