### PR TITLE
fix(changelog): support custom Jinja extensions in release notes templates

### DIFF
--- a/src/semantic_release/cli/commands/changelog.py
+++ b/src/semantic_release/cli/commands/changelog.py
@@ -161,6 +161,7 @@ def changelog(cli_ctx: CliContextObj, release_tag: str | None) -> None:
             tag_name=release_tag,
             project_root=runtime.repo_dir,
         ),
+        template_environment=runtime.template_environment,
     )
 
     try:

--- a/src/semantic_release/cli/commands/version.py
+++ b/src/semantic_release/cli/commands/version.py
@@ -705,6 +705,7 @@ def version(  # noqa: C901
         style=runtime.changelog_style,
         mask_initial_release=runtime.changelog_mask_initial_release,
         license_name="" if not isinstance(license_cfg, str) else license_cfg,
+        template_environment=runtime.template_environment,
     )
 
     # Preparing for committing changes; we always stage files even if we're not committing them in order to support a two-stage commit


### PR DESCRIPTION
## Purpose

Closes #1402

Custom Jinja extensions configured via `[tool.semantic_release.changelog.environment]` were only available in changelog templates, but not in release notes templates.

This PR applies the same `changelog.environment` configuration when rendering custom release notes templates.

## Rationale

The `generate_release_notes()` function was creating a separate, non-configurable Jinja environment that ignored user settings. This was inconsistent with how `write_changelog_files()` handles custom templates.

The fix follows the same pattern used for changelog templates:

- if custom template exists, use the user's configured `template_environment`
- otherwise use a plain default environment to ensure compatibility

## How did you test?

`test_release_notes_uses_custom_jinja_extension`: Verifies custom Jinja extensions with filters are available in release notes templates. All existing release notes tests continue to pass.

## How to Verify

1. Configure a custom Jinja extension in `pyproject.toml`:

   ```toml
   [tool.semantic_release.changelog.environment]
   extensions = ["my_package.ext:MyCustomExtension"]
   ```

2. Create a custom `.release_notes.md.j2` template using a filter from the extension:

   ```jinja
   {{ "text" | my_custom_filter }}
   ```

3. Run `semantic-release changelog --post-to-release-tag <tag>` or `semantic-release version`

4. Verify the release notes render correctly with the custom filter applied

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [ ] Appropriate End-to-End tests added/updated

- [ ] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)