### PR TITLE
feat(changelog): Add `changelog.output_dir` configuration option

### DIFF
--- a/docs/concepts/changelog_templates.rst
+++ b/docs/concepts/changelog_templates.rst
@@ -408,6 +408,22 @@ Importantly, note the following:
   file ``ch-templates/static/config.cfg`` is *copied, not rendered* to the new top-level
   ``static`` folder.
 
+.. tip::
+   By default, templates are rendered relative to the project root. To render templates
+   to a different directory (e.g., ``docs/``), use the :ref:`output_dir <config-changelog-output_dir>`
+   setting:
+
+   .. code-block:: toml
+
+       [tool.semantic_release.changelog]
+       template_dir = "ch-templates"
+       output_dir = "docs"
+
+   This will render all templates to the ``docs/`` directory instead of the project root.
+
+   This is particularly useful in :ref:`monorepo setups <monorepos>` where you want to
+   consolidate changelogs into a shared documentation directory for multiple packages.
+
 You may wish to leverage this behavior to modularize your changelog template, to
 define macros in a separate file, or to reference static data which you would like
 to avoid duplicating between your template environment and the remainder of your

--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -744,6 +744,40 @@ This option is discussed in more detail at :ref:`changelog-templates`
 
 ----
 
+.. _config-changelog-output_dir:
+
+``output_dir``
+**************
+
+**Type:** ``str``
+
+Specifies the directory where rendered changelog templates will be written. By default,
+templates are rendered to the project root directory. Use this setting to output the
+changelog to a different location, such as a ``docs/`` subdirectory.
+
+When using the default changelog template (no custom ``template_dir``), the changelog
+file will be placed at ``<output_dir>/<changelog_file_name>``. For example, with
+``output_dir = "docs"`` and the default ``changelog_file = "CHANGELOG.md"``, the
+changelog will be written to ``docs/CHANGELOG.md``.
+
+When using custom templates via ``template_dir``, the entire template directory structure
+will be rendered relative to ``output_dir`` instead of the project root.
+
+.. note::
+   You cannot specify both ``output_dir`` and a directory path in ``changelog_file``.
+   Use ``output_dir`` for the destination directory and ``changelog_file`` for just the
+   filename. For example, use ``output_dir = "docs"`` with ``changelog_file = "CHANGELOG.md"``
+   rather than ``changelog_file = "docs/CHANGELOG.md"``.
+
+**Default:** ``"."`` (project root)
+
+.. seealso::
+
+   - :ref:`monorepos` - Using ``output_dir`` to consolidate changelogs in monorepo documentation directories
+   - :ref:`changelog-templates` - Custom template directory rendering with ``output_dir``
+
+----
+
 .. _config-commit_author:
 
 ``commit_author``


### PR DESCRIPTION
## Purpose

This PR adds a new `changelog.output_dir` configuration option that allows users to specify the destination directory for changelog output.

This feature is particularly valuable for monorepo setups where PSR runs from a package subdirectory but needs to write changelogs to a consolidated documentation directory, and also when users use shared remote templates (see #1404) across multiple projects but still want fine grained control over where the changelog is written.

## Rationale

In monorepo environments, users often want to:
- Run PSR from a package directory (e.g., `packages/pkg1/`)
- Write changelogs to a centralized docs folder (e.g., `docs/source/pkg1/changelog.md`)

Before this PR, achieving this required complex shell scripts to copy/move changelog files. The previous monorepo documentation reflected this complexity, requiring users to understand intricate template customization just to place changelogs in a different directory.

The new `output_dir` option provides a simple way to specify the changelog destination:

```toml
# packages/pkg1/pyproject.toml
[tool.semantic_release.changelog]
output_dir = "../../docs/source/pkg1"
```

This single line replaces what previously required custom templates and shell scripts. The Advanced Example in the monorepo documentation has been completely rewritten to use `output_dir`, reducing complexity significantly while enabling the same (and more) functionality.

## Bug Fix: Custom Templates Now Render to CWD

This PR also fixes an inconsistency when using custom template directories from a subdirectory.

**Before:**
```python
# changelog_writer.py
project_dir = Path(runtime_ctx.repo_dir)  # Always repo root
...
destination_dir=project_dir  # Hardcoded to repo root
```

**After:**
```python
# changelog_writer.py
output_dir = runtime_ctx.output_dir  # Resolved from "." relative to CWD
...
destination_dir=output_dir  # Respects CWD
```

The old behavior was inconsistent: when running from a subdirectory (e.g., `packages/pkg1/`), `template_dir` was resolved relative to CWD, but `destination_dir` was always hardcoded to the repository root. This caused templates to be read from the subdirectory but output to be written to the repo root.

With this fix, both template reading and output writing are consistent: relative to CWD when `output_dir="."` (default), or to the explicitly configured `output_dir`. I'm expecting this to be related to #845, and could potentially fix it.

## How did you test?

### Unit Tests (`tests/unit/semantic_release/cli/test_config.py`)
- `test_output_dir_default_resolves_to_repo_root` - Default behavior
- `test_output_dir_inside_repo_accepted` - Valid paths accepted
- `test_output_dir_outside_repo_rejected` - Security: paths outside repo rejected
- `test_output_dir_with_parent_traversal_rejected` - Security: path traversal blocked
- `test_output_dir_and_changelog_file_with_dir_rejected` - Ambiguous config rejected
- `test_output_dir_with_bare_changelog_filename_from_subdirectory_accepted` - Monorepo scenario works

### End-to-End Tests (`tests/e2e/cmd_changelog/test_changelog.py`)
- `test_changelog_generated_in_output_dir` - Changelog written to specified directory
- `test_changelog_update_mode_reads_from_output_dir` - Update mode reads existing changelog from correct location
- `test_changelog_file_with_directory_component_backward_compatibility` - Existing `changelog_file` with directory component still works

### Backward Compatibility
- Existing configurations with `changelog_file = "docs/CHANGELOG.md"` (directory component) continue to work unchanged
- The validation only triggers when `output_dir` is explicitly set alongside a `changelog_file` with directory component

## How to Verify

1. **Basic usage**: Set `output_dir` in config and run `semantic-release changelog`
   ```toml
   [tool.semantic_release.changelog]
   output_dir = "docs"
   ```
   Verify changelog is written to `docs/CHANGELOG.md`

2. **Monorepo scenario**: From a package subdirectory with:
   ```toml
   [tool.semantic_release.changelog]
   output_dir = "../../docs/source/pkg1"
   ```
   Run `semantic-release changelog` and verify output location

3. **Update mode**: Create an existing changelog in `output_dir`, run with `mode = "update"`, verify it reads and updates the correct file

4. **Backward compatibility**: Existing config with `changelog_file = "docs/CHANGELOG.md"` (no `output_dir`) should continue working

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)