### PR TITLE
feat(parser-emoji): define non-version-bumping emojis

### DIFF
--- a/src/semantic_release/commit_parser/emoji.py
+++ b/src/semantic_release/commit_parser/emoji.py
@@ -65,7 +65,12 @@ class EmojiParserOptions(ParserOptions):
     )
     """Commit-type prefixes that should result in a patch release bump."""
 
-    other_allowed_tags: Tuple[str, ...] = (":memo:", ":checkmark:")
+    other_allowed_tags: Tuple[str, ...] = (
+        ":checkmark:",
+        ":construction_worker:",
+        ":memo:",
+        ":recycle:",
+    )
     """Commit-type prefixes that are allowed but do not result in a version bump."""
 
     allowed_tags: Tuple[str, ...] = (

--- a/tests/const.py
+++ b/tests/const.py
@@ -93,7 +93,7 @@ EMOJI_COMMITS_PATCH = (
 )
 EMOJI_COMMITS_MINOR = (
     *EMOJI_COMMITS_PATCH,
-    ":sparkles::pencil: docs for something special\n",
+    ":sparkles::memo: docs for something special\n",
     # Emoji in description should not be used to evaluate change type
     ":sparkles: last minute rush order\n\nGood thing we're 10x developers :boom:\n",
 )

--- a/tests/unit/semantic_release/commit_parser/test_emoji.py
+++ b/tests/unit/semantic_release/commit_parser/test_emoji.py
@@ -42,20 +42,28 @@ if TYPE_CHECKING:
             [":bug: Fixing a bug", "The bug is finally gone!"],
             [],
         ),
-        # No release
+        # No release with specified emoji
         (
-            ":pencil: Documentation changes",
+            ":memo: Documentation changes",
+            LevelBump.NO_RELEASE,
+            ":memo:",
+            [":memo: Documentation changes"],
+            [],
+        ),
+        # No release with random emoji
+        (
+            ":construction: Work in progress",
             LevelBump.NO_RELEASE,
             "Other",
-            [":pencil: Documentation changes"],
+            [":construction: Work in progress"],
             [],
         ),
         # Multiple emojis
         (
-            ":sparkles::pencil: Add a feature and document it",
+            ":sparkles::memo: Add a feature and document it",
             LevelBump.MINOR,
             ":sparkles:",
-            [":sparkles::pencil: Add a feature and document it"],
+            [":sparkles::memo: Add a feature and document it"],
             [],
         ),
         # Emoji in description


### PR DESCRIPTION
## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Refactors PR #963

## How did you test?

For E2E testing, the test `tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel.py::test_githubflow_repo_rebuild_1_channel[repo_w_github_flow_w_default_release_channel_emoji_commits]` includes a `:memo:` commit and if you look at the changelog created during this test, the resulting changelog consolidates all memo commits into its own descriptive category and not a catch all `### Other` section.

Example with default configuration settings:

<details>
<summary>
<code>.pytest_cache/d/psr-cached-repos/repo_w_github_flow_w_default_release_channel_emoji_commits/CHANGELOG.md</code>
</summary>

```md
# CHANGELOG

<!-- version list -->

## v1.1.0 (2026-01-04)

### :checkmark:

- :checkmark: add cli tests ([#3](https://example.com/example_owner/example_repo/pull/3),
  [`e37ae7e`](https://example.com/example_owner/example_repo/commit/e37ae7e9fde4617aafaf22036ede8ea670d98b66))

### :memo:

- :memo: add cli documentation ([#3](https://example.com/example_owner/example_repo/pull/3),
  [`e37ae7e`](https://example.com/example_owner/example_repo/commit/e37ae7e9fde4617aafaf22036ede8ea670d98b66))

### :sparkles:

- :sparkles: add cli interface ([#3](https://example.com/example_owner/example_repo/pull/3),
  [`e37ae7e`](https://example.com/example_owner/example_repo/commit/e37ae7e9fde4617aafaf22036ede8ea670d98b66))


## v1.0.1 (2026-01-04)

### :bug:

- :bug: add missing text ([#2](https://example.com/example_owner/example_repo/pull/2),
  [`ed72544`](https://example.com/example_owner/example_repo/commit/ed72544021ae3b6a68f9bf0e6f865b086a8df6bb))


## v1.0.0 (2026-01-04)

- Initial Release

```

</details>

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
