### PR TITLE
docs: fix broken PyPI link to changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ semantic-release = "semantic_release.__main__:main"
 psr = "semantic_release.__main__:main"
 
 [project.urls]
-changelog = "https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.md"
+changelog = "https://python-semantic-release.readthedocs.io/en/stable/misc/psr_changelog.html"
 documentation = "https://python-semantic-release.readthedocs.io"
 homepage = "https://python-semantic-release.readthedocs.io"
 issues = "https://github.com/python-semantic-release/python-semantic-release/issues"


### PR DESCRIPTION
## Purpose

Fix link on PyPI.

## Rationale

On the [PyPI page](https://pypi.org/project/python-semantic-release/), the "changelog" link pointed to a 404 because it assumed Markdown instead of reSTructred text.

## How did you test?

I can't really, this need to be published on PyPI.

## How to Verify

1. After merging this, publish a release.
2. Navigate to https://pypi.org/project/python-semantic-release/
3. In the sidebar on the left, click "changelog"

Expected result: Shows changelog instead of 404.

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [x] Changes Implemented & Validation pipeline succeeds ❌ Can't, see comment above.

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated ❌ n/a

- [x] Appropriate End-to-End tests added/updated ❌ n/a

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines) ❌ It's a docs fix.
