### PR TITLE
fix: use rprint instead of click.echo for Rich markup error messages

### DIFF
--- a/src/semantic_release/cli/commands/version.py
+++ b/src/semantic_release/cli/commands/version.py
@@ -591,19 +591,14 @@ def version(  # noqa: C901
     # If the new version has already been released, we fail and abort if strict;
     # otherwise we exit with 0.
     if new_version in previously_released_versions:
-        err_msg = str.join(
-            " ",
-            [
-                "[bold orange1]No release will be made,",
-                f"{new_version!s} has already been released!",
-            ],
-        )
+        err_msg = f"No release will be made, {new_version!s} has already been released!"
+        orange1_code = 214  # https://rich.readthedocs.io/en/stable/appendix/colors.html
 
         if opts.strict:
-            click.echo(err_msg, err=True)
+            click.secho(err_msg, err=True, fg=orange1_code, bold=True)
             ctx.exit(2)
 
-        rprint(err_msg)
+        click.secho(err_msg, err=True, fg=orange1_code, bold=True)
         return
 
     if print_only or print_only_tag:

--- a/tests/e2e/cmd_version/test_version_strict.py
+++ b/tests/e2e/cmd_version/test_version_strict.py
@@ -44,7 +44,9 @@ def test_version_already_released_when_strict(
     latest_release_version = get_versions_from_repo_build_def(
         repo_result["definition"]
     )[-1]
-    expected_error_msg = f"[bold orange1]No release will be made, {latest_release_version} has already been released!"
+    expected_error_msg = (
+        f"No release will be made, {latest_release_version} has already been released!"
+    )
 
     # Setup: take measurement before running the version command
     repo_status_before = repo.git.status(short=True)


### PR DESCRIPTION
## Problem

When running `semantic-release --verbose --noop --strict version` with no new commits since the last release, the error message is printed with literal Rich markup tags instead of formatted text:

**Actual:** `[bold orange1]No release will be made, ...`  
**Expected:** Formatted bold orange message

## Root cause

In `cli/commands/version.py`, the `if opts.strict` branch uses `click.echo(err_msg, err=True)` which doesn't process Rich markup. The non-strict path correctly uses `rprint(err_msg)`.

## Fix

Replace `click.echo(err_msg, err=True)` with `rprint(err_msg, file=sys.stderr)` so both paths render Rich markup consistently.

Fixes #1423