### PR TITLE
fix: use resolve() instead of absolute() in verify_git_repo_dir

### DIFF
--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -1208,6 +1208,25 @@ from the :ref:`remote.name <config-remote-name>` location of your git repository
 
 ----
 
+.. _config-repo_dir:
+
+``repo_dir``
+""""""""""""
+
+**Type:** ``str``
+
+Specify the directory of the Git repository. This is used to determine the location of
+the repository for various operations, such as creating tags and commits. PSR will attempt
+to automatically determine the location of the repository in parent directories of the
+current working directory but will emit a warning if it is higher than this defined value.
+
+If a git repository is not found from this location or any parent directories, PSR will
+raise an error and exit.
+
+**Default:** ``"."``
+
+----
+
 .. _config-tag_format:
 
 ``tag_format``

--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -120,6 +120,52 @@ sure to use the correct root key depending on the configuration format you are u
 
 ----
 
+.. _config-add_partial_tags:
+
+``add_partial_tags``
+""""""""""""""""""""
+
+**Type:** ``bool``
+
+Specify if partial version tags should be handled when creating a new version. If set to
+``true``, a ``major`` and a ``major.minor`` tag will be created or updated, using the format
+specified in :ref:`tag_format`. If version has build metadata, a ``major.minor.patch`` tag
+will also be created or updated.
+
+Partial version tags are **disabled** for pre-release versions.
+
+**Example**
+
+.. code-block:: toml
+
+    [semantic_release]
+    tag_format = "v{version}"
+    add_partial_tags = true
+
+This configuration with the next version of ``1.2.3`` will result in:
+
+.. code-block:: bash
+
+    git log --decorate --oneline --graph --all
+    # * 4d4cb0a (tag: v1.2.3, tag: v1.2, tag: v1, origin/main, main) 1.2.3
+    # * 3a2b1c0 fix: some bug
+    # * 2b1c0a9 (tag: v1.2.2) 1.2.2
+    # ...
+
+If build-metadata is used, the next version of ``1.2.3+20251109`` will result in:
+
+.. code-block:: bash
+
+    git log --decorate --oneline --graph --all
+    # * 4d4cb0a (tag: v1.2.3+20251109, tag: v1.2.3, tag: v1.2, tag: v1, origin/main, main) 1.2.3+20251109
+    # * 3a2b1c0 chore: add partial tags to PSR configuration
+    # * 2b1c0a9 (tag: v1.2.3+20251031) 1.2.3+20251031
+    # ...
+
+**Default:** ``false``
+
+----
+
 .. _config-allow_zero_version:
 
 ``allow_zero_version``
@@ -1159,52 +1205,6 @@ This setting will override the upstream location url that would normally be deri
 from the :ref:`remote.name <config-remote-name>` location of your git repository.
 
 **Default:** ``None``
-
-----
-
-.. _config-add_partial_tags:
-
-``add_partial_tags``
-""""""""""""""""""""
-
-**Type:** ``bool``
-
-Specify if partial version tags should be handled when creating a new version. If set to
-``true``, a ``major`` and a ``major.minor`` tag will be created or updated, using the format
-specified in :ref:`tag_format`. If version has build metadata, a ``major.minor.patch`` tag
-will also be created or updated.
-
-Partial version tags are **disabled** for pre-release versions.
-
-**Example**
-
-.. code-block:: toml
-
-    [semantic_release]
-    tag_format = "v{version}"
-    add_partial_tags = true
-
-This configuration with the next version of ``1.2.3`` will result in:
-
-.. code-block:: bash
-
-    git log --decorate --oneline --graph --all
-    # * 4d4cb0a (tag: v1.2.3, tag: v1.2, tag: v1, origin/main, main) 1.2.3
-    # * 3a2b1c0 fix: some bug
-    # * 2b1c0a9 (tag: v1.2.2) 1.2.2
-    # ...
-
-If build-metadata is used, the next version of ``1.2.3+20251109`` will result in:
-
-.. code-block:: bash
-
-    git log --decorate --oneline --graph --all
-    # * 4d4cb0a (tag: v1.2.3+20251109, tag: v1.2.3, tag: v1.2, tag: v1, origin/main, main) 1.2.3+20251109
-    # * 3a2b1c0 chore: add partial tags to PSR configuration
-    # * 2b1c0a9 (tag: v1.2.3+20251031) 1.2.3+20251031
-    # ...
-
-**Default:** ``false``
 
 ----
 

--- a/src/semantic_release/cli/config.py
+++ b/src/semantic_release/cli/config.py
@@ -13,7 +13,18 @@ from re import (
     error as RegExpError,  # noqa: N812
     escape as regex_escape,
 )
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 # typing_extensions is for Python 3.8, 3.9, 3.10 compatibility
 import tomlkit
@@ -363,7 +374,7 @@ class RawConfig(BaseModel):
     logging_use_named_masks: bool = False
     major_on_zero: bool = True
     allow_zero_version: bool = False
-    repo_dir: Annotated[Path, Field(validate_default=True)] = Path(".")
+    repo_dir: Path = Field(default=cast("Path", "."), validate_default=True)
     remote: RemoteConfig = RemoteConfig()
     no_git_verify: bool = False
     tag_format: str = "v{version}"
@@ -388,18 +399,19 @@ class RawConfig(BaseModel):
                 found_path = (
                     Path(git_repo.working_tree_dir or git_repo.working_dir)
                     .expanduser()
+                    .resolve()
                     .absolute()
                 )
 
         except InvalidGitRepositoryError as err:
-            raise InvalidGitRepositoryError("No valid git repository found!") from err
+            msg = "No valid git repository found!"
+            raise InvalidGitRepositoryError(msg) from err
 
-        if dir_path.absolute() != found_path:
-            logging.warning(
-                "Found .git/ in higher parent directory rather than provided in configuration."
-            )
+        if dir_path.resolve().absolute() != found_path:
+            msg = "Found .git/ in higher parent directory rather than provided in configuration."
+            logger.warning(msg)
 
-        return found_path.resolve()
+        return found_path
 
     @field_validator("commit_parser", mode="after")
     @classmethod

--- a/tests/e2e/cmd_version/bump_version/git_flow/test_repo_1_channel.py
+++ b/tests/e2e/cmd_version/bump_version/git_flow/test_repo_1_channel.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.git_flow import (
     repo_w_git_flow_emoji_commits,
     repo_w_git_flow_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def test_gitflow_repo_rebuild_1_channel(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -153,6 +154,8 @@ def test_gitflow_repo_rebuild_1_channel(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/git_flow/test_repo_2_channels.py
+++ b/tests/e2e/cmd_version/bump_version/git_flow/test_repo_2_channels.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.git_flow import (
     repo_w_git_flow_w_alpha_prereleases_n_emoji_commits,
     repo_w_git_flow_w_alpha_prereleases_n_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def test_gitflow_repo_rebuild_2_channels(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -153,6 +154,8 @@ def test_gitflow_repo_rebuild_2_channels(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/git_flow/test_repo_3_channels.py
+++ b/tests/e2e/cmd_version/bump_version/git_flow/test_repo_3_channels.py
@@ -11,7 +11,7 @@ from tests.fixtures.repos.git_flow import (
     repo_w_git_flow_w_rc_n_alpha_prereleases_n_emoji_commits,
     repo_w_git_flow_w_rc_n_alpha_prereleases_n_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -68,6 +68,7 @@ def test_gitflow_repo_rebuild_3_channels(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -154,6 +155,8 @@ def test_gitflow_repo_rebuild_3_channels(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/git_flow/test_repo_4_channels.py
+++ b/tests/e2e/cmd_version/bump_version/git_flow/test_repo_4_channels.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.git_flow import (
     repo_w_git_flow_w_beta_alpha_rev_prereleases_n_emoji_commits,
     repo_w_git_flow_w_beta_alpha_rev_prereleases_n_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def test_gitflow_repo_rebuild_4_channels(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -153,6 +154,8 @@ def test_gitflow_repo_rebuild_4_channels(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel.py
+++ b/tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.github_flow import (
     repo_w_github_flow_w_default_release_channel_emoji_commits,
     repo_w_github_flow_w_default_release_channel_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def test_githubflow_repo_rebuild_1_channel(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -153,6 +154,8 @@ def test_githubflow_repo_rebuild_1_channel(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel_branch_update_merge.py
+++ b/tests/e2e/cmd_version/bump_version/github_flow/test_repo_1_channel_branch_update_merge.py
@@ -13,7 +13,7 @@ from tests.fixtures.repos.github_flow import (
     repo_w_github_flow_w_default_release_n_branch_update_merge_emoji_commits,
     repo_w_github_flow_w_default_release_n_branch_update_merge_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -72,6 +72,7 @@ def test_github_flow_repo_w_default_release_n_branch_update_merge(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -166,6 +167,8 @@ def test_github_flow_repo_w_default_release_n_branch_update_merge(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/github_flow/test_repo_2_channels.py
+++ b/tests/e2e/cmd_version/bump_version/github_flow/test_repo_2_channels.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.github_flow import (
     repo_w_github_flow_w_feature_release_channel_emoji_commits,
     repo_w_github_flow_w_feature_release_channel_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def test_githubflow_repo_rebuild_2_channels(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -153,6 +154,8 @@ def test_githubflow_repo_rebuild_2_channels(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/github_flow_monorepo/test_monorepo_1_channel.py
+++ b/tests/e2e/cmd_version/bump_version/github_flow_monorepo/test_monorepo_1_channel.py
@@ -12,7 +12,7 @@ from tests.const import RepoActionStep
 from tests.fixtures.monorepos.github_flow import (
     monorepo_w_github_flow_w_default_release_channel_conventional_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from typing import Literal, Sequence
@@ -71,6 +71,7 @@ def test_githubflow_monorepo_rebuild_1_channel(
     monorepo_pkg2_changelog_md_file: Path,
     monorepo_pkg1_changelog_rst_file: Path,
     monorepo_pkg2_changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -225,6 +226,10 @@ def test_githubflow_monorepo_rebuild_1_channel(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we have configured repo_dir
+        # to be the parent directory from where PSR is being run, so although it is in the
+        # parent directory, it is known to the user and should not be a warning
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert (
             expected_pkg1_pyproject_toml_content == actual_pkg1_pyproject_toml_content

--- a/tests/e2e/cmd_version/bump_version/github_flow_monorepo/test_monorepo_2_channels.py
+++ b/tests/e2e/cmd_version/bump_version/github_flow_monorepo/test_monorepo_2_channels.py
@@ -12,7 +12,7 @@ from tests.const import RepoActionStep
 from tests.fixtures.monorepos.github_flow import (
     monorepo_w_github_flow_w_feature_release_channel_conventional_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from typing import Literal, Sequence
@@ -71,6 +71,7 @@ def test_githubflow_monorepo_rebuild_2_channels(
     monorepo_pkg2_changelog_md_file: Path,
     monorepo_pkg1_changelog_rst_file: Path,
     monorepo_pkg2_changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -224,6 +225,10 @@ def test_githubflow_monorepo_rebuild_2_channels(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we have configured repo_dir
+        # to be the parent directory from where PSR is being run, so although it is in the
+        # parent directory, it is known to the user and should not be a warning
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert (
             expected_pkg1_pyproject_toml_content == actual_pkg1_pyproject_toml_content

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.trunk_based_dev import (
     repo_w_trunk_only_emoji_commits,
     repo_w_trunk_only_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -68,6 +68,7 @@ def test_trunk_repo_rebuild_only_official_releases(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -155,6 +156,8 @@ def test_trunk_repo_rebuild_only_official_releases(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support.py
@@ -13,7 +13,7 @@ from tests.fixtures.repos.trunk_based_dev import (
     repo_w_trunk_only_dual_version_spt_emoji_commits,
     repo_w_trunk_only_dual_version_spt_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -69,6 +69,7 @@ def test_trunk_repo_rebuild_dual_version_spt_official_releases_only(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -161,6 +162,8 @@ def test_trunk_repo_rebuild_dual_version_spt_official_releases_only(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support_w_prereleases.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_dual_version_support_w_prereleases.py
@@ -13,7 +13,7 @@ from tests.fixtures.repos.trunk_based_dev import (
     repo_w_trunk_only_dual_version_spt_w_prereleases_emoji_commits,
     repo_w_trunk_only_dual_version_spt_w_prereleases_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -70,6 +70,7 @@ def test_trunk_repo_rebuild_dual_version_spt_w_official_n_prereleases(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -162,6 +163,8 @@ def test_trunk_repo_rebuild_dual_version_spt_w_official_n_prereleases(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_w_prereleases.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev/test_repo_trunk_w_prereleases.py
@@ -10,7 +10,7 @@ from tests.fixtures.repos.trunk_based_dev import (
     repo_w_trunk_only_n_prereleases_emoji_commits,
     repo_w_trunk_only_n_prereleases_scipy_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def test_trunk_repo_rebuild_w_prereleases(
     pyproject_toml_file: Path,
     changelog_md_file: Path,
     changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -153,6 +154,8 @@ def test_trunk_repo_rebuild_w_prereleases(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we are running in the same directory as the .git repo
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert expected_pyproject_toml_content == actual_pyproject_toml_content
         assert expected_version_file_content == actual_version_file_content

--- a/tests/e2e/cmd_version/bump_version/trunk_based_dev_monorepo/test_monorepo_trunk.py
+++ b/tests/e2e/cmd_version/bump_version/trunk_based_dev_monorepo/test_monorepo_trunk.py
@@ -12,7 +12,7 @@ from tests.const import RepoActionStep
 from tests.fixtures.monorepos.trunk_based_dev import (
     monorepo_w_trunk_only_releases_conventional_commits,
 )
-from tests.util import temporary_working_directory
+from tests.util import assert_str_not_in_output, temporary_working_directory
 
 if TYPE_CHECKING:
     from typing import Literal, Sequence
@@ -71,6 +71,7 @@ def test_trunk_monorepo_rebuild_1_channel(
     monorepo_pkg2_changelog_md_file: Path,
     monorepo_pkg1_changelog_rst_file: Path,
     monorepo_pkg2_changelog_rst_file: Path,
+    caplog: pytest.LogCaptureFixture,
 ):
     # build target repo into a temporary directory
     target_repo_dir = example_project_dir / repo_fixture_name
@@ -225,6 +226,10 @@ def test_trunk_monorepo_rebuild_1_channel(
 
         # Evaluate (normal release actions should have occurred as expected)
         # ------------------------------------------------------------------
+        # The warning should not be present in the logs since we have configured repo_dir
+        # to be the parent directory from where PSR is being run, so although it is in the
+        # parent directory, it is known to the user and should not be a warning
+        assert_str_not_in_output("Found .git/ in higher parent directory", caplog.text)
         # Make sure version file is updated
         assert (
             expected_pkg1_pyproject_toml_content == actual_pkg1_pyproject_toml_content

--- a/tests/e2e/cmd_version/test_version.py
+++ b/tests/e2e/cmd_version/test_version.py
@@ -13,11 +13,14 @@ from tests.const import (
     MAIN_PROG_NAME,
     VERSION_SUBCMD,
 )
+from tests.fixtures.monorepos import (
+    monorepo_w_trunk_only_releases_conventional_commits,
+)
 from tests.fixtures.repos import (
     repo_w_no_tags_conventional_commits,
     repo_w_trunk_only_conventional_commits,
 )
-from tests.util import assert_successful_exit_code
+from tests.util import assert_successful_exit_code, temporary_working_directory
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -291,3 +294,40 @@ def test_version_only_tag_push(
     assert head_before == head_after
     assert mocked_git_push.call_count == 1  # 0 for commit, 1 for tag
     assert post_mocker.call_count == 1
+
+
+@pytest.mark.usefixtures(monorepo_w_trunk_only_releases_conventional_commits.__name__)
+def test_version_warning_on_not_configured_repo_dir(
+    run_cli: RunCliFn,
+    update_pyproject_toml: UpdatePyprojectTomlFn,
+    monorepo_pkg1_pyproject_toml_file: Path,
+    monorepo_pkg1_dir: Path,
+):
+    """
+    Given a repo with a subdirectory that is not configured in the pyproject.toml,
+    When running the version command from that subdirectory,
+    Then a warning should be printed to stderr indicating that the .git directory
+    was found in a higher parent directory.
+
+    Note: we are using a monorepo for testing since it will automatically set up a
+    subdirectory with a pyproject.toml file and the .git/ directory in a parent
+    directory by default, making it easy to test. The successful measure of no
+    warning is tested throughout the e2e tests for cmd-version.
+    """
+    # Setup: set the repo_dir to None in the pyproject.toml of a subdirectory of the repo
+    update_pyproject_toml(
+        "tool.semantic_release.repo_dir",
+        None,
+        monorepo_pkg1_pyproject_toml_file,
+    )
+
+    # Act
+    cli_cmd = [MAIN_PROG_NAME, VERSION_SUBCMD, "--print"]
+
+    # Act: Run release on a subdirectory of the repo that is not configured in the pyproject.toml
+    with temporary_working_directory(monorepo_pkg1_dir):
+        result = run_cli(cli_cmd[1:], env={Github.DEFAULT_ENV_TOKEN_NAME: "1234"})
+
+    # Evaluate
+    assert_successful_exit_code(result, cli_cmd)
+    assert "Found .git/ in higher parent directory" in result.stderr

--- a/tests/fixtures/example_project.py
+++ b/tests/fixtures/example_project.py
@@ -367,9 +367,14 @@ def get_parser_from_config_file(
     def _get_parser_from_config(
         file: Path | str = pyproject_toml_file,
     ) -> CommitParser[ParseResult, ParserOptions]:
-        return load_runtime_context(
-            cli_opts=GlobalCommandLineOptions(config_file=str(Path(file)))
-        ).commit_parser
+        file_path = Path(file).resolve()
+
+        # Use a temporary working directory to ensure that the current working directory
+        # does not affect the loading of the runtime context and commit parser.
+        with temporary_working_directory(file_path.parent):
+            return load_runtime_context(
+                cli_opts=GlobalCommandLineOptions(config_file=str(file_path))
+            ).commit_parser
 
     return _get_parser_from_config
 

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -1574,7 +1574,9 @@ def build_repo_from_definition(  # noqa: C901, its required and its just test co
 
                     # Helpful Transform to find the project root repo without needing to pass it around (ie '/' => repo_dir)
                     new_cwd = (
-                        repo_dir if str(new_cwd) == str(repo_dir.root) else new_cwd
+                        repo_dir
+                        if str(new_cwd) == str(Path(repo_dir.root).resolve())
+                        else new_cwd
                     )
 
                     if not new_cwd.is_dir():

--- a/tests/fixtures/monorepos/example_monorepo.py
+++ b/tests/fixtures/monorepos/example_monorepo.py
@@ -180,6 +180,34 @@ def cached_example_monorepo(
                 ],
                 cached_project_path / monorepo_pkg2_pyproject_toml_file,
             ),
+            (
+                "tool.semantic_release.repo_dir",
+                str(
+                    Path(
+                        *(
+                            ".."
+                            for _ in range(
+                                len(monorepo_pkg1_pyproject_toml_file.parent.parts)
+                            )
+                        )
+                    )
+                ),
+                cached_project_path / monorepo_pkg1_pyproject_toml_file,
+            ),
+            (
+                "tool.semantic_release.repo_dir",
+                str(
+                    Path(
+                        *(
+                            ".."
+                            for _ in range(
+                                len(monorepo_pkg2_pyproject_toml_file.parent.parts)
+                            )
+                        )
+                    )
+                ),
+                cached_project_path / monorepo_pkg2_pyproject_toml_file,
+            ),
         ]
 
         for setting, value, toml_file in config_updates:

--- a/tests/util.py
+++ b/tests/util.py
@@ -79,6 +79,29 @@ def assert_successful_exit_code(result: ClickInvokeResult, cli_cmd: list[str]) -
     return assert_exit_code(SUCCESS_EXIT_CODE, result, cli_cmd)
 
 
+def assert_str_not_in_output(substring: str, output: str) -> bool:
+    found_lines: list[str] = list(
+        filter(
+            lambda line, substr=substring: substr in line,  # type: ignore[arg-type]
+            output.splitlines(),
+        )
+    )
+    num_found_lines = len(found_lines)
+
+    if num_found_lines == 0:
+        return True
+
+    raise AssertionError(
+        str.join(
+            os.linesep,
+            [
+                f"Found {num_found_lines} lines in output containing {substring!r}:",
+                indent(str.join(os.linesep, found_lines), " " * 2),
+            ],
+        )
+    )
+
+
 def get_full_qualname(callable_obj: Callable[[Any], Any]) -> str:
     parts = filter(
         None,


### PR DESCRIPTION
In monorepo setups where `repo_dir='..'` is configured for a subpackage, `Path('..').absolute()` returns `/path/to/package/..` rather than the resolved `/path/to/repo`. Using `resolve()` properly handles symlinks and normalizes paths, preventing false 'Found .git/ in higher parent directory' warnings.

Fixes python-semantic-release/python-semantic-release#1418