### PR TITLE
fix(helpers): mask credentials in git URL debug logs

### DIFF
--- a/src/semantic_release/helpers.py
+++ b/src/semantic_release/helpers.py
@@ -9,7 +9,7 @@ from functools import lru_cache, reduce, wraps
 from pathlib import Path, PurePosixPath
 from re import IGNORECASE, compile as regexp
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Sequence, TypeVar
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from semantic_release.globals import logger
 
@@ -215,6 +215,16 @@ class ParsedGitUrl(NamedTuple):
     repo_name: str
 
 
+def _hide_credentials_in_url(url: str) -> str:
+    url_parts = urlsplit(url)
+
+    if not url_parts.scheme or "@" not in url_parts.netloc:
+        return url
+
+    _, _, host = url_parts.netloc.rpartition("@")
+    return urlunsplit(url_parts._replace(netloc=f"<credentials>@{host}"))
+
+
 @lru_cache(maxsize=512)
 def parse_git_url(url: str) -> ParsedGitUrl:
     """
@@ -242,7 +252,7 @@ def parse_git_url(url: str) -> ParsedGitUrl:
 
     Raises ValueError if the url can't be parsed.
     """
-    logger.debug("Parsing git url %r", url)
+    logger.debug("Parsing git url %r", _hide_credentials_in_url(url))
 
     # Normalizers are a list of tuples of (pattern, replacement)
     normalizers = [

--- a/tests/unit/semantic_release/test_helpers.py
+++ b/tests/unit/semantic_release/test_helpers.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 import pytest
 
+from semantic_release.globals import logger
 from semantic_release.helpers import ParsedGitUrl, parse_git_url, sort_numerically
 
 
@@ -118,6 +119,30 @@ from semantic_release.helpers import ParsedGitUrl, parse_git_url, sort_numerical
 def test_parse_valid_git_urls(url: str, expected: ParsedGitUrl):
     """Test that a valid given git remote url is parsed correctly."""
     assert expected == parse_git_url(url)
+
+
+def test_parse_git_url_does_not_log_credentials(caplog: pytest.LogCaptureFixture):
+    """Test that credentials in git urls are masked before logging."""
+    username = "x-oauth-basic"
+    secret = "ghp_secret_token"
+    url = f"https://{username}:{secret}@github.example.com/owner/project.git"
+
+    parse_git_url.cache_clear()
+    caplog.set_level("DEBUG", logger=logger.name)
+
+    expected_parsed_url = ParsedGitUrl(
+        "https",
+        f"{username}:{secret}@github.example.com",
+        "owner",
+        "project",
+    )
+
+    actual_parsed_url = parse_git_url(url)
+
+    assert expected_parsed_url == actual_parsed_url
+    assert username not in caplog.text
+    assert secret not in caplog.text
+    assert "<credentials>@github.example.com" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

Fixes #1426 by preventing credentials embedded in HTTPS git remotes from being written to debug logs when `parse_git_url()` starts parsing a URL.

## Rationale

The parser should still receive and return the original URL data, but the log message does not need to include userinfo from the URL netloc. This changes only the value passed to the debug log call, replacing any `user[:password]@host` section with `<credentials>@host` while leaving parsing behavior unchanged.

## How did you test?

- Added a focused unit test that parses a remote like `https://x-oauth-basic:<token>@github.example.com/owner/project.git`, confirms parsing still succeeds, and confirms the token/username are absent from captured logs.
- Ran `python -m pytest tests/unit/semantic_release/test_helpers.py -q`.
- Ran `ruff check src/semantic_release/helpers.py tests/unit/semantic_release/test_helpers.py`.
- Ran `ruff format --check src/semantic_release/helpers.py tests/unit/semantic_release/test_helpers.py`.

## How to Verify

1. Run `python -m pytest tests/unit/semantic_release/test_helpers.py -q`.
2. Optionally run semantic-release with `-vv` against an HTTPS remote containing userinfo and confirm the `Parsing git url` debug line shows `<credentials>@host` instead of the raw credential-bearing URL.

---

## PR Completion Checklist

- [x] Reviewed & followed the [Contributor Guidelines](https://python-semantic-release.readthedocs.io/en/stable/contributing/contributing_guide.html)

- [ ] Changes Implemented & Validation pipeline succeeds
  - Targeted local validation passed; full validation pipeline was not run locally.

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
  and are separated into the proper commit type and scope (recommended order: test, build, feat/fix, docs)

- [x] Appropriate Unit tests added/updated

- [x] Appropriate End-to-End tests added/updated
  - Not applicable; this is covered by a unit-level logging regression test.

- [x] Appropriate Documentation added/updated and syntax validated for sphinx build (see Contributor Guidelines)
  - Not applicable; no documentation changed.